### PR TITLE
*: extract interface to be implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ vendor
 test-infra/vendor
 
 .vscode
-
+test-infra

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
+PACKAGE_LIST := go list ./... | grep -vE "vendor"
+PACKAGE_DIRECTORIES := $(PACKAGE_LIST) | sed 's|github.com/pingcap/tipocket/||'
+
 default: build
 
 all: build
 
-build: chaos verifier
+build: fmt chaos verifier
 
 chaos: rawkv tidb txnkv
 
@@ -17,3 +20,15 @@ txnkv:
 
 verifier:
 	GO111MODULE=on go build -o bin/chaos-verifier cmd/verifier/main.go
+
+fmt: groupimports
+	go fmt ./...
+
+groupimports: install-goimports
+	goimports -w -l -local github.com/pingcap/tipocket $$($(PACKAGE_DIRECTORIES))
+
+install-goimports:
+ifeq (,$(shell which goimports))
+	@echo "installing goimports"
+	go get golang.org/x/tools/cmd/goimports
+endif

--- a/cmd/rawkv/main.go
+++ b/cmd/rawkv/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"github.com/pingcap/tipocket/pkg/cluster"
 	"log"
 	"time"
 
@@ -54,5 +55,5 @@ func main() {
 		Nemesises:     *nemesises,
 		VerifySuit:    verifySuit,
 	}
-	suit.Run(context.Background(), []string{})
+	suit.Run(context.Background(), []cluster.Node{})
 }

--- a/cmd/rawkv/main.go
+++ b/cmd/rawkv/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/pingcap/tipocket/pkg/cluster"
 	"log"
 	"time"
 
@@ -55,5 +54,5 @@ func main() {
 		Nemesises:     *nemesises,
 		VerifySuit:    verifySuit,
 	}
-	suit.Run(context.Background(), []cluster.Node{})
+	suit.Run(context.Background())
 }

--- a/cmd/tidb/main.go
+++ b/cmd/tidb/main.go
@@ -46,12 +46,12 @@ func main() {
 	switch *clientCase {
 	case "bank":
 		creator = tidb.BankClientCreator{}
-	case "multi_bank":
-		creator = tidb.MultiBankClientCreator{}
+	//case "multi_bank":
+	//	creator = tidb.MultiBankClientCreator{}
 	case "long_fork":
 		creator = tidb.LongForkClientCreator{}
-	case "sequential":
-		creator = tidb.SequentialClientCreator{}
+	//case "sequential":
+	//	creator = tidb.SequentialClientCreator{}
 	default:
 		log.Fatalf("invalid client test case %s", *clientCase)
 	}
@@ -68,10 +68,10 @@ func main() {
 		checker = tidb.LongForkChecker()
 		parser = tidb.LongForkParser()
 		model = nil
-	case "sequential_checker":
-		checker = tidb.NewSequentialChecker()
-		parser = tidb.NewSequentialParser()
-		model = nil
+	//case "sequential_checker":
+	//	checker = tidb.NewSequentialChecker()
+	//	parser = tidb.NewSequentialParser()
+	//	model = nil
 	default:
 		log.Fatalf("invalid checker %s", *checkerNames)
 	}
@@ -87,5 +87,5 @@ func main() {
 		Nemesises:     *nemesises,
 		VerifySuit:    verifySuit,
 	}
-	suit.Run(context.Background(), []string{})
+	suit.Run(context.Background())
 }

--- a/cmd/txnkv/main.go
+++ b/cmd/txnkv/main.go
@@ -54,5 +54,5 @@ func main() {
 		Nemesises:     *nemesises,
 		VerifySuit:    verifySuit,
 	}
-	suit.Run(context.Background(), []string{})
+	suit.Run(context.Background())
 }

--- a/cmd/util/suit.go
+++ b/cmd/util/suit.go
@@ -2,7 +2,7 @@ package util
 
 import (
 	"context"
-	"fmt"
+	"github.com/pingcap/tipocket/pkg/cluster"
 	"log"
 	"os"
 	"os/signal"
@@ -18,6 +18,8 @@ import (
 // Suit is a basic chaos testing suit with configurations to run chaos.
 type Suit struct {
 	*control.Config
+	// Provisioner deploy the SUT cluster
+	cluster.Provisioner
 	core.ClientCreator
 	// nemesis, seperated by comma.
 	Nemesises string
@@ -26,7 +28,8 @@ type Suit struct {
 }
 
 // Run runs the suit.
-func (suit *Suit) Run(ctx context.Context, nodes []string) {
+func (suit *Suit) Run(ctx context.Context) {
+	var err error
 	var nemesisGens []core.NemesisGenerator
 	for _, name := range strings.Split(suit.Nemesises, ",") {
 		var g core.NemesisGenerator
@@ -49,15 +52,20 @@ func (suit *Suit) Run(ctx context.Context, nodes []string) {
 
 	sctx, cancel := context.WithCancel(ctx)
 
-	if len(nodes) != 0 {
-		suit.Config.Nodes = nodes
-	} else {
-		// By default, we run TiKV/TiDB cluster on 5 nodes.
-		for i := 1; i <= 5; i++ {
-			name := fmt.Sprintf("n%d", i)
-			suit.Config.Nodes = append(suit.Config.Nodes, name)
-		}
+	err, suit.Config.Nodes = suit.Provisioner.SetUp(sctx, nil)
+	if err != nil {
+		log.Fatalf("deploy a cluster failed, err: %s", err)
 	}
+
+	//if len(nodes) != 0 {
+	//	suit.Config.Nodes = nodes
+	//} else {
+	//	// By default, we run TiKV/TiDB cluster on 5 nodes.
+	//	for i := 1; i <= 5; i++ {
+	//		name := fmt.Sprintf("n%d", i)
+	//		suit.Config.Nodes = append(suit.Config.Nodes, name)
+	//	}
+	//}
 
 	c := control.NewController(
 		sctx,

--- a/cmd/util/suit.go
+++ b/cmd/util/suit.go
@@ -2,12 +2,13 @@ package util
 
 import (
 	"context"
-	"github.com/pingcap/tipocket/pkg/cluster"
 	"log"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
+
+	"github.com/pingcap/tipocket/pkg/cluster"
 
 	"github.com/pingcap/tipocket/pkg/control"
 	"github.com/pingcap/tipocket/pkg/core"

--- a/cmd/util/suit.go
+++ b/cmd/util/suit.go
@@ -57,16 +57,6 @@ func (suit *Suit) Run(ctx context.Context) {
 		log.Fatalf("deploy a cluster failed, err: %s", err)
 	}
 
-	//if len(nodes) != 0 {
-	//	suit.Config.Nodes = nodes
-	//} else {
-	//	// By default, we run TiKV/TiDB cluster on 5 nodes.
-	//	for i := 1; i <= 5; i++ {
-	//		name := fmt.Sprintf("n%d", i)
-	//		suit.Config.Nodes = append(suit.Config.Nodes, name)
-	//	}
-	//}
-
 	c := control.NewController(
 		sctx,
 		suit.Config,

--- a/cmd/verifier/main.go
+++ b/cmd/verifier/main.go
@@ -50,8 +50,8 @@ func main() {
 			case "tidb_bank_tso":
 				// Actually we can omit BankModel, since BankTsoChecker does not require a Model.
 				s.Model, s.Parser, s.Checker = tidb.BankModel(), tidb.BankParser(), tidb.BankTsoChecker()
-			case "sequential":
-				s.Parser, s.Checker = tidb.NewSequentialParser(), tidb.NewSequentialChecker()
+			//case "sequential":
+			//	s.Parser, s.Checker = tidb.NewSequentialParser(), tidb.NewSequentialChecker()
 			case "register":
 				s.Model, s.Parser, s.Checker = model.RegisterModel(), model.RegisterParser(), porcupine.Checker{}
 			case "":

--- a/db/cluster/cluster.go
+++ b/db/cluster/cluster.go
@@ -3,13 +3,14 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tipocket/pkg/cluster"
 	"log"
 	"path"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/pingcap/tipocket/pkg/cluster"
 
 	"github.com/pingcap/tipocket/pkg/util"
 	"github.com/pingcap/tipocket/pkg/util/ssh"

--- a/db/rawkv/register.go
+++ b/db/rawkv/register.go
@@ -9,10 +9,12 @@ import (
 	"time"
 
 	"github.com/anishathalye/porcupine"
-	"github.com/pingcap/tipocket/pkg/core"
-	"github.com/pingcap/tipocket/pkg/model"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/store/tikv"
+
+	"github.com/pingcap/tipocket/pkg/cluster"
+	"github.com/pingcap/tipocket/pkg/core"
+	"github.com/pingcap/tipocket/pkg/model"
 )
 
 var (
@@ -24,7 +26,7 @@ type registerClient struct {
 	r  *rand.Rand
 }
 
-func (c *registerClient) SetUp(ctx context.Context, nodes []string, node string) error {
+func (c *registerClient) SetUp(ctx context.Context, nodes []cluster.Node, node cluster.Node) error {
 	c.r = rand.New(rand.NewSource(time.Now().UnixNano()))
 	db, err := tikv.NewRawKVClient([]string{fmt.Sprintf("%s:2379", node)}, config.Security{})
 	if err != nil {
@@ -45,7 +47,7 @@ func (c *registerClient) SetUp(ctx context.Context, nodes []string, node string)
 	return nil
 }
 
-func (c *registerClient) TearDown(ctx context.Context, nodes []string, node string) error {
+func (c *registerClient) TearDown(ctx context.Context, nodes []cluster.Node, node cluster.Node) error {
 	return c.db.Close()
 }
 
@@ -61,7 +63,7 @@ func (c *registerClient) invokeRead(ctx context.Context, r model.RegisterRequest
 	return model.RegisterResponse{Value: int(v)}
 }
 
-func (c *registerClient) Invoke(ctx context.Context, node string, r interface{}) interface{} {
+func (c *registerClient) Invoke(ctx context.Context, node cluster.Node, r interface{}) interface{} {
 	arg := r.(model.RegisterRequest)
 	if arg.Op == model.RegisterRead {
 		return c.invokeRead(ctx, arg)
@@ -113,6 +115,6 @@ type RegisterClientCreator struct {
 }
 
 // Create creates a client.
-func (RegisterClientCreator) Create(node string) core.Client {
+func (RegisterClientCreator) Create(node cluster.Node) core.Client {
 	return &registerClient{}
 }

--- a/db/tidb/bank.go
+++ b/db/tidb/bank.go
@@ -5,13 +5,15 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/pingcap/tipocket/pkg/cluster"
 	"log"
 	"math/rand"
 	"sort"
 	"time"
 
+	"github.com/pingcap/tipocket/pkg/cluster"
+
 	"github.com/anishathalye/porcupine"
+
 	pchecker "github.com/pingcap/tipocket/pkg/check/porcupine"
 	"github.com/pingcap/tipocket/pkg/core"
 	"github.com/pingcap/tipocket/pkg/history"

--- a/db/tidb/long_fork.go
+++ b/db/tidb/long_fork.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"github.com/pingcap/tipocket/pkg/cluster"
 	"hash/fnv"
 	"log"
 	"math/rand"
@@ -39,11 +40,11 @@ var (
 	lfState = struct {
 		mu      sync.Mutex
 		nextKey uint64
-		workers map[string]uint64
+		workers map[*cluster.Node]uint64
 	}{
 		mu:      sync.Mutex{},
 		nextKey: 0,
-		workers: make(map[string]uint64),
+		workers: make(map[*cluster.Node]uint64),
 	}
 )
 
@@ -51,7 +52,7 @@ type longForkClient struct {
 	db         *sql.DB
 	r          *rand.Rand
 	tableCount int
-	node       string
+	node       cluster.Node
 }
 
 func lfTableNames(tableCount int) []string {
@@ -71,9 +72,9 @@ func lfKey2Table(tableCount int, key uint64) string {
 	return fmt.Sprintf("txn_lf_%d", hash%tableCount)
 }
 
-func (c *longForkClient) SetUp(ctx context.Context, nodes []string, node string) error {
+func (c *longForkClient) SetUp(ctx context.Context, nodes []cluster.Node, node cluster.Node) error {
 	c.r = rand.New(rand.NewSource(time.Now().UnixNano()))
-	db, err := sql.Open("mysql", fmt.Sprintf("root@tcp(%s:4000)/test", node))
+	db, err := sql.Open("mysql", fmt.Sprintf("root@tcp(%s:%s)/test", node.IP, node.Port))
 	if err != nil {
 		return err
 	}
@@ -103,11 +104,11 @@ func (c *longForkClient) SetUp(ctx context.Context, nodes []string, node string)
 	return nil
 }
 
-func (c *longForkClient) TearDown(ctx context.Context, nodes []string, node string) error {
+func (c *longForkClient) TearDown(ctx context.Context, nodes []cluster.Node, node cluster.Node) error {
 	return c.db.Close()
 }
 
-func (c *longForkClient) Invoke(ctx context.Context, node string, r interface{}) interface{} {
+func (c *longForkClient) Invoke(ctx context.Context, node cluster.Node, r interface{}) interface{} {
 	arg := r.(lfRequest)
 	if arg.Kind == lfWrite {
 
@@ -155,9 +156,9 @@ func (c *longForkClient) NextRequest() interface{} {
 	lfState.mu.Lock()
 	defer lfState.mu.Unlock()
 
-	key, present := lfState.workers[c.node]
+	key, present := lfState.workers[&c.node]
 	if present {
-		delete(lfState.workers, c.node)
+		delete(lfState.workers, &c.node)
 		return lfRequest{Kind: lfRead, Keys: makeKeysInGroup(c.r, lfGroupSize, key)}
 	}
 
@@ -176,7 +177,7 @@ func (c *longForkClient) NextRequest() interface{} {
 
 	key = lfState.nextKey
 	lfState.nextKey++
-	lfState.workers[c.node] = key
+	lfState.workers[&c.node] = key
 	return lfRequest{Kind: lfWrite, Keys: []uint64{key}}
 }
 
@@ -199,7 +200,7 @@ type LongForkClientCreator struct {
 }
 
 // Create creates a new longForkClient.
-func (LongForkClientCreator) Create(node string) core.Client {
+func (LongForkClientCreator) Create(node cluster.Node) core.Client {
 	return &longForkClient{
 		tableCount: 7,
 		node:       node,

--- a/db/tidb/long_fork.go
+++ b/db/tidb/long_fork.go
@@ -6,13 +6,14 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"github.com/pingcap/tipocket/pkg/cluster"
 	"hash/fnv"
 	"log"
 	"math/rand"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/pingcap/tipocket/pkg/cluster"
 
 	"github.com/pingcap/tipocket/pkg/core"
 	"github.com/pingcap/tipocket/pkg/history"

--- a/db/tidb/multi_bank.go
+++ b/db/tidb/multi_bank.go
@@ -1,185 +1,185 @@
 package tidb
-
-import (
-	"context"
-	"database/sql"
-	"fmt"
-	"log"
-	"math/rand"
-	"time"
-
-	"github.com/pingcap/tipocket/pkg/core"
-)
-
-type multiBankClient struct {
-	db         *sql.DB
-	r          *rand.Rand
-	accountNum int
-}
-
-func (c *multiBankClient) SetUp(ctx context.Context, nodes []string, node string) error {
-	c.r = rand.New(rand.NewSource(time.Now().UnixNano()))
-	db, err := sql.Open("mysql", fmt.Sprintf("root@tcp(%s:4000)/test", node))
-	if err != nil {
-		return err
-	}
-	c.db = db
-
-	db.SetMaxIdleConns(1 + c.accountNum)
-
-	// Do SetUp in the first node
-	if node != nodes[0] {
-		return nil
-	}
-
-	log.Printf("begin to create table accounts on node %s", node)
-
-	for i := 0; i < c.accountNum; i++ {
-		sql := fmt.Sprintf(`create table if not exists accounts_%d
-			(id     int not null primary key,
-			balance bigint not null)`, i)
-
-		if _, err = db.ExecContext(ctx, sql); err != nil {
-			return err
-		}
-
-		sql = fmt.Sprintf("insert into accounts_%d values (?, ?)", i)
-		if _, err = db.ExecContext(ctx, sql, i, initBalance); err != nil {
-			return err
-		}
-
-	}
-
-	return nil
-}
-
-func (c *multiBankClient) TearDown(ctx context.Context, nodes []string, node string) error {
-	return c.db.Close()
-}
-
-func (c *multiBankClient) invokeRead(ctx context.Context, r bankRequest) bankResponse {
-	txn, err := c.db.Begin()
-
-	if err != nil {
-		return bankResponse{Unknown: true}
-	}
-	defer txn.Rollback()
-
-	var tso uint64
-	if err = txn.QueryRow("select @@tidb_current_ts").Scan(&tso); err != nil {
-		return bankResponse{Unknown: true}
-	}
-
-	balances := make([]int64, 0, c.accountNum)
-	for i := 0; i < c.accountNum; i++ {
-		var balance int64
-		sql := fmt.Sprintf("select balance from accounts_%d", i)
-		if err = txn.QueryRowContext(ctx, sql).Scan(&balance); err != nil {
-			return bankResponse{Unknown: true}
-		}
-		balances = append(balances, balance)
-	}
-
-	return bankResponse{Balances: balances, Tso: tso}
-}
-
-func (c *multiBankClient) Invoke(ctx context.Context, node string, r interface{}) interface{} {
-	arg := r.(bankRequest)
-	if arg.Op == 0 {
-		return c.invokeRead(ctx, arg)
-	}
-
-	txn, err := c.db.Begin()
-
-	if err != nil {
-		return bankResponse{Ok: false}
-	}
-	defer txn.Rollback()
-
-	var (
-		fromBalance int64
-		toBalance   int64
-		tso         uint64
-	)
-
-	if err = txn.QueryRow("select @@tidb_current_ts").Scan(&tso); err != nil {
-		return bankResponse{Ok: false}
-	}
-
-	if err = txn.QueryRowContext(ctx, fmt.Sprintf("select balance from accounts_%d where id = ? for update", arg.From), arg.From).Scan(&fromBalance); err != nil {
-		return bankResponse{Ok: false}
-	}
-
-	if err = txn.QueryRowContext(ctx, fmt.Sprintf("select balance from accounts_%d where id = ? for update", arg.To), arg.To).Scan(&toBalance); err != nil {
-		return bankResponse{Ok: false}
-	}
-
-	if fromBalance < arg.Amount {
-		return bankResponse{Ok: false}
-	}
-
-	if _, err = txn.ExecContext(ctx, fmt.Sprintf("update accounts_%d set balance = balance - ? where id = ?", arg.From), arg.Amount, arg.From); err != nil {
-		return bankResponse{Ok: false}
-	}
-
-	if _, err = txn.ExecContext(ctx, fmt.Sprintf("update accounts_%d set balance = balance + ? where id = ?", arg.To), arg.Amount, arg.To); err != nil {
-		return bankResponse{Ok: false}
-	}
-
-	if err = txn.Commit(); err != nil {
-		return bankResponse{Unknown: true, Tso: tso, FromBalance: fromBalance, ToBalance: toBalance}
-	}
-
-	return bankResponse{Ok: true, Tso: tso, FromBalance: fromBalance, ToBalance: toBalance}
-}
-
-func (c *multiBankClient) NextRequest() interface{} {
-	r := bankRequest{
-		Op: c.r.Int() % 2,
-	}
-	if r.Op == 0 {
-		return r
-	}
-
-	r.From = c.r.Intn(c.accountNum)
-
-	r.To = c.r.Intn(c.accountNum)
-	if r.From == r.To {
-		r.To = (r.To + 1) % c.accountNum
-	}
-
-	r.Amount = 5
-	return r
-}
-
-// DumpState the database state(also the model's state)
-func (c *multiBankClient) DumpState(ctx context.Context) (interface{}, error) {
-	txn, err := c.db.Begin()
-
-	if err != nil {
-		return nil, err
-	}
-	defer txn.Rollback()
-
-	balances := make([]int64, 0, c.accountNum)
-	for i := 0; i < c.accountNum; i++ {
-		var balance int64
-		sql := fmt.Sprintf("select balance from accounts_%d", i)
-		if err = txn.QueryRowContext(ctx, sql).Scan(&balance); err != nil {
-			return nil, err
-		}
-		balances = append(balances, balance)
-	}
-	return balances, nil
-}
-
-// MultiBankClientCreator creates a bank test client for tidb.
-type MultiBankClientCreator struct {
-}
-
-// Create creates a client.
-func (MultiBankClientCreator) Create(node string) core.Client {
-	return &multiBankClient{
-		accountNum: accountNum,
-	}
-}
+//
+//import (
+//	"context"
+//	"database/sql"
+//	"fmt"
+//	"log"
+//	"math/rand"
+//	"time"
+//
+//	"github.com/pingcap/tipocket/pkg/core"
+//)
+//
+//type multiBankClient struct {
+//	db         *sql.DB
+//	r          *rand.Rand
+//	accountNum int
+//}
+//
+//func (c *multiBankClient) SetUp(ctx context.Context, nodes []string, node string) error {
+//	c.r = rand.New(rand.NewSource(time.Now().UnixNano()))
+//	db, err := sql.Open("mysql", fmt.Sprintf("root@tcp(%s:4000)/test", node))
+//	if err != nil {
+//		return err
+//	}
+//	c.db = db
+//
+//	db.SetMaxIdleConns(1 + c.accountNum)
+//
+//	// Do SetUp in the first node
+//	if node != nodes[0] {
+//		return nil
+//	}
+//
+//	log.Printf("begin to create table accounts on node %s", node)
+//
+//	for i := 0; i < c.accountNum; i++ {
+//		sql := fmt.Sprintf(`create table if not exists accounts_%d
+//			(id     int not null primary key,
+//			balance bigint not null)`, i)
+//
+//		if _, err = db.ExecContext(ctx, sql); err != nil {
+//			return err
+//		}
+//
+//		sql = fmt.Sprintf("insert into accounts_%d values (?, ?)", i)
+//		if _, err = db.ExecContext(ctx, sql, i, initBalance); err != nil {
+//			return err
+//		}
+//
+//	}
+//
+//	return nil
+//}
+//
+//func (c *multiBankClient) TearDown(ctx context.Context, nodes []string, node string) error {
+//	return c.db.Close()
+//}
+//
+//func (c *multiBankClient) invokeRead(ctx context.Context, r bankRequest) bankResponse {
+//	txn, err := c.db.Begin()
+//
+//	if err != nil {
+//		return bankResponse{Unknown: true}
+//	}
+//	defer txn.Rollback()
+//
+//	var tso uint64
+//	if err = txn.QueryRow("select @@tidb_current_ts").Scan(&tso); err != nil {
+//		return bankResponse{Unknown: true}
+//	}
+//
+//	balances := make([]int64, 0, c.accountNum)
+//	for i := 0; i < c.accountNum; i++ {
+//		var balance int64
+//		sql := fmt.Sprintf("select balance from accounts_%d", i)
+//		if err = txn.QueryRowContext(ctx, sql).Scan(&balance); err != nil {
+//			return bankResponse{Unknown: true}
+//		}
+//		balances = append(balances, balance)
+//	}
+//
+//	return bankResponse{Balances: balances, Tso: tso}
+//}
+//
+//func (c *multiBankClient) Invoke(ctx context.Context, node string, r interface{}) interface{} {
+//	arg := r.(bankRequest)
+//	if arg.Op == 0 {
+//		return c.invokeRead(ctx, arg)
+//	}
+//
+//	txn, err := c.db.Begin()
+//
+//	if err != nil {
+//		return bankResponse{Ok: false}
+//	}
+//	defer txn.Rollback()
+//
+//	var (
+//		fromBalance int64
+//		toBalance   int64
+//		tso         uint64
+//	)
+//
+//	if err = txn.QueryRow("select @@tidb_current_ts").Scan(&tso); err != nil {
+//		return bankResponse{Ok: false}
+//	}
+//
+//	if err = txn.QueryRowContext(ctx, fmt.Sprintf("select balance from accounts_%d where id = ? for update", arg.From), arg.From).Scan(&fromBalance); err != nil {
+//		return bankResponse{Ok: false}
+//	}
+//
+//	if err = txn.QueryRowContext(ctx, fmt.Sprintf("select balance from accounts_%d where id = ? for update", arg.To), arg.To).Scan(&toBalance); err != nil {
+//		return bankResponse{Ok: false}
+//	}
+//
+//	if fromBalance < arg.Amount {
+//		return bankResponse{Ok: false}
+//	}
+//
+//	if _, err = txn.ExecContext(ctx, fmt.Sprintf("update accounts_%d set balance = balance - ? where id = ?", arg.From), arg.Amount, arg.From); err != nil {
+//		return bankResponse{Ok: false}
+//	}
+//
+//	if _, err = txn.ExecContext(ctx, fmt.Sprintf("update accounts_%d set balance = balance + ? where id = ?", arg.To), arg.Amount, arg.To); err != nil {
+//		return bankResponse{Ok: false}
+//	}
+//
+//	if err = txn.Commit(); err != nil {
+//		return bankResponse{Unknown: true, Tso: tso, FromBalance: fromBalance, ToBalance: toBalance}
+//	}
+//
+//	return bankResponse{Ok: true, Tso: tso, FromBalance: fromBalance, ToBalance: toBalance}
+//}
+//
+//func (c *multiBankClient) NextRequest() interface{} {
+//	r := bankRequest{
+//		Op: c.r.Int() % 2,
+//	}
+//	if r.Op == 0 {
+//		return r
+//	}
+//
+//	r.From = c.r.Intn(c.accountNum)
+//
+//	r.To = c.r.Intn(c.accountNum)
+//	if r.From == r.To {
+//		r.To = (r.To + 1) % c.accountNum
+//	}
+//
+//	r.Amount = 5
+//	return r
+//}
+//
+//// DumpState the database state(also the model's state)
+//func (c *multiBankClient) DumpState(ctx context.Context) (interface{}, error) {
+//	txn, err := c.db.Begin()
+//
+//	if err != nil {
+//		return nil, err
+//	}
+//	defer txn.Rollback()
+//
+//	balances := make([]int64, 0, c.accountNum)
+//	for i := 0; i < c.accountNum; i++ {
+//		var balance int64
+//		sql := fmt.Sprintf("select balance from accounts_%d", i)
+//		if err = txn.QueryRowContext(ctx, sql).Scan(&balance); err != nil {
+//			return nil, err
+//		}
+//		balances = append(balances, balance)
+//	}
+//	return balances, nil
+//}
+//
+//// MultiBankClientCreator creates a bank test client for tidb.
+//type MultiBankClientCreator struct {
+//}
+//
+//// Create creates a client.
+//func (MultiBankClientCreator) Create(node string) core.Client {
+//	return &multiBankClient{
+//		accountNum: accountNum,
+//	}
+//}

--- a/db/tidb/multi_bank.go
+++ b/db/tidb/multi_bank.go
@@ -1,4 +1,5 @@
 package tidb
+
 //
 //import (
 //	"context"

--- a/db/tidb/sequential.go
+++ b/db/tidb/sequential.go
@@ -1,292 +1,292 @@
 package tidb
-
-import (
-	"context"
-	"database/sql"
-	"encoding/json"
-	"fmt"
-	"hash/fnv"
-	"log"
-	"math/rand"
-	"sync"
-	"time"
-
-	"github.com/pingcap/tipocket/pkg/generator"
-	"github.com/pingcap/tipocket/pkg/history"
-
-	"github.com/pingcap/tipocket/pkg/core"
-)
-
-const (
-	tablePrefix = "seq_"
-	tpRead      = "read"
-	tpWrite     = "write"
-)
-
-type seqRequest struct {
-	Tp string
-	K  int
-}
-
-type seqResponse struct {
-	Ok      bool
-	K       int
-	V       []string
-	Unknown bool
-}
-
-var (
-	_ core.UnknownResponse = (*seqResponse)(nil)
-
-	queue = struct {
-		mu    sync.Mutex
-		q     []int
-		count int
-		r     *rand.Rand
-	}{
-		mu: sync.Mutex{},
-		q:  make([]int, 0, 10), // TODO: make the cap configurable.
-		r:  rand.New(rand.NewSource(time.Now().UnixNano())),
-	}
-)
-
-// IsUnknown implements UnknownResponse interface
-func (r seqResponse) IsUnknown() bool {
-	return r.Unknown
-}
-
-type sequentialClient struct {
-	db         *sql.DB
-	tableCount int
-	keyCount   int
-	gen        generator.Generator
-}
-
-// SequentialClientCreator creates a bank test client for tidb.
-type SequentialClientCreator struct {
-}
-
-func genRequest() interface{} {
-	queue.mu.Lock()
-	defer queue.mu.Unlock()
-	c := cap(queue.q)
-	l := len(queue.q)
-	k := queue.count
-	// The first len(queue.q) requests are all write requests.
-	if k < c {
-		goto WRITE
-	} else if l == c {
-		// Read if the queue is full
-		goto READ
-	} else if l <= 3 {
-		// Write if the queue is empty
-		goto WRITE
-	} else if queue.r.Int()%2 == 1 {
-		goto READ
-	} else {
-		goto WRITE
-	}
-
-READ:
-	// Read
-	// Pop the front
-	k, queue.q = queue.q[0], append([]int{}, queue.q[1:]...)
-	return seqRequest{Tp: tpRead, K: k}
-WRITE:
-	// Write
-	// Push the end
-	queue.count++
-	queue.q = append(queue.q, k)
-	return seqRequest{Tp: tpWrite, K: k}
-}
-
-// Create creates a new SequentialClient.
-func (SequentialClientCreator) Create(node string) core.Client {
-	return &sequentialClient{
-		tableCount: 3,
-		keyCount:   5,
-		gen:        generator.Stagger(time.Millisecond*10, genRequest),
-	}
-}
-
-func (c *sequentialClient) tableNames() []string {
-	names := make([]string, 0, c.tableCount)
-	for i := 0; i < c.tableCount; i++ {
-		names = append(names, fmt.Sprintf("%s%d", tablePrefix, i))
-	}
-	return names
-}
-
-func subkeys(keyCount int, k int) []string {
-	ks := make([]string, 0, keyCount)
-	for i := 0; i < keyCount; i++ {
-		ks = append(ks, fmt.Sprintf("%d_%d", k, i))
-	}
-	return ks
-}
-
-func hash(s string) int {
-	h := fnv.New32a()
-	h.Write([]byte(s))
-	return int(h.Sum32())
-}
-
-func key2table(tableCount int, key string) string {
-	return fmt.Sprintf("%s%d", tablePrefix, hash(key)%tableCount)
-}
-
-// SetUp sets up the client.
-func (c *sequentialClient) SetUp(ctx context.Context, nodes []string, node string) error {
-	db, err := sql.Open("mysql", fmt.Sprintf("root@tcp(%s:4000)/test", node))
-	if err != nil {
-		return err
-	}
-	c.db = db
-
-	db.SetMaxIdleConns(1 + c.tableCount)
-
-	// Do SetUp in the first node
-	if node != nodes[0] {
-		return nil
-	}
-
-	tableNames := c.tableNames()
-	log.Printf("begin to create table %v on node %s", tableNames, node)
-	for _, tableName := range tableNames {
-		log.Printf("try to drop table %s", tableName)
-		if _, err = db.ExecContext(ctx,
-			fmt.Sprintf(" drop table if exists %s", tableName)); err != nil {
-			return err
-		}
-		sql := `create table if not exists %s (tkey varchar(255) primary key)`
-		if _, err = db.ExecContext(ctx, fmt.Sprintf(sql, tableName)); err != nil {
-			return err
-		}
-		log.Printf("created table %s", tableName)
-	}
-
-	return nil
-}
-
-// TearDown tears down the client.
-func (c *sequentialClient) TearDown(ctx context.Context, nodes []string, node string) error {
-	return c.db.Close()
-}
-
-// Invoke invokes a request to the database.
-// Mostly, the return Response should implement UnknownResponse interface
-func (c *sequentialClient) Invoke(ctx context.Context, node string, r interface{}) interface{} {
-	req := r.(seqRequest)
-	ks := subkeys(c.keyCount, req.K)
-	if req.Tp == tpWrite {
-		for _, k := range ks {
-			sql := fmt.Sprintf("insert into %s values (?)", key2table(c.tableCount, k))
-			_, err := c.db.ExecContext(ctx, sql, k)
-			if err != nil {
-				// TODO: retry on conflict
-				log.Println(err)
-				return seqResponse{Ok: false}
-			}
-		}
-		return seqResponse{Ok: true}
-	} else if req.Tp == tpRead {
-		vs := make([]string, 0, len(ks))
-		for i := len(ks) - 1; i >= 0; i-- {
-			k := ks[i]
-			sql := fmt.Sprintf("select tkey from %s where tkey = ?", key2table(c.tableCount, k))
-			var v string
-			err := c.db.QueryRowContext(ctx, sql, k).Scan(&v)
-			if err != nil {
-				// TODO: retry on conflict
-				log.Println(err)
-				return seqResponse{Ok: false}
-			}
-			vs = append(vs, v)
-		}
-		resp := seqResponse{
-			Ok: true,
-			K:  req.K,
-			V:  vs,
-		}
-		return resp
-	} else {
-		panic(fmt.Sprintf("unknown req %v", req))
-	}
-}
-
-// NextRequest generates a request for latter Invoke.
-func (c *sequentialClient) NextRequest() interface{} {
-	return c.gen()
-}
-
-// DumpState the database state(also the model's state)
-func (c *sequentialClient) DumpState(ctx context.Context) (interface{}, error) {
-	return nil, nil
-}
-
-// NewSequentialChecker returns a new sequentialChecker.
-func NewSequentialChecker() core.Checker {
-	return sequentialChecker{}
-}
-
-// sequentialChecker checks whether a history is sequential.
-type sequentialChecker struct{}
-
-// Check checks the sequential history.
-func (sequentialChecker) Check(_ core.Model, ops []core.Operation) (bool, error) {
-	for _, op := range ops {
-		if op.Action == core.ReturnOperation {
-			resp := op.Data.(seqResponse)
-			if !resp.Unknown && resp.Ok {
-				foundNoneEmpty := false
-				for _, s := range resp.V {
-					if !foundNoneEmpty {
-						foundNoneEmpty = s != ""
-					} else if s == "" {
-						log.Printf("Find no sequential op %+v", resp)
-						return false, nil
-					}
-				}
-			}
-		}
-	}
-	return true, nil
-}
-
-// Name returns the name of the verifier.
-func (sequentialChecker) Name() string {
-	return "sequential_checker"
-}
-
-type parser struct{}
-
-// OnRequest impls history.RecordParser.OnRequest
-func (p parser) OnRequest(data json.RawMessage) (interface{}, error) {
-	r := seqRequest{}
-	err := json.Unmarshal(data, &r)
-	return r, err
-}
-
-// OnResponse impls history.RecordParser.OnRequest
-func (p parser) OnResponse(data json.RawMessage) (interface{}, error) {
-	r := seqResponse{}
-	err := json.Unmarshal(data, &r)
-	if r.Unknown {
-		return nil, err
-	}
-	return r, err
-}
-
-// OnNoopResponse impls history.RecordParser.OnRequest
-func (p parser) OnNoopResponse() interface{} {
-	return seqResponse{Unknown: true}
-}
-
-func (p parser) OnState(data json.RawMessage) (interface{}, error) {
-	return nil, nil
-}
-
-// NewSequentialParser returns a parser parses a history of bank operations.
-func NewSequentialParser() history.RecordParser {
-	return parser{}
-}
+//
+//import (
+//	"context"
+//	"database/sql"
+//	"encoding/json"
+//	"fmt"
+//	"hash/fnv"
+//	"log"
+//	"math/rand"
+//	"sync"
+//	"time"
+//
+//	"github.com/pingcap/tipocket/pkg/generator"
+//	"github.com/pingcap/tipocket/pkg/history"
+//
+//	"github.com/pingcap/tipocket/pkg/core"
+//)
+//
+//const (
+//	tablePrefix = "seq_"
+//	tpRead      = "read"
+//	tpWrite     = "write"
+//)
+//
+//type seqRequest struct {
+//	Tp string
+//	K  int
+//}
+//
+//type seqResponse struct {
+//	Ok      bool
+//	K       int
+//	V       []string
+//	Unknown bool
+//}
+//
+//var (
+//	_ core.UnknownResponse = (*seqResponse)(nil)
+//
+//	queue = struct {
+//		mu    sync.Mutex
+//		q     []int
+//		count int
+//		r     *rand.Rand
+//	}{
+//		mu: sync.Mutex{},
+//		q:  make([]int, 0, 10), // TODO: make the cap configurable.
+//		r:  rand.New(rand.NewSource(time.Now().UnixNano())),
+//	}
+//)
+//
+//// IsUnknown implements UnknownResponse interface
+//func (r seqResponse) IsUnknown() bool {
+//	return r.Unknown
+//}
+//
+//type sequentialClient struct {
+//	db         *sql.DB
+//	tableCount int
+//	keyCount   int
+//	gen        generator.Generator
+//}
+//
+//// SequentialClientCreator creates a bank test client for tidb.
+//type SequentialClientCreator struct {
+//}
+//
+//func genRequest() interface{} {
+//	queue.mu.Lock()
+//	defer queue.mu.Unlock()
+//	c := cap(queue.q)
+//	l := len(queue.q)
+//	k := queue.count
+//	// The first len(queue.q) requests are all write requests.
+//	if k < c {
+//		goto WRITE
+//	} else if l == c {
+//		// Read if the queue is full
+//		goto READ
+//	} else if l <= 3 {
+//		// Write if the queue is empty
+//		goto WRITE
+//	} else if queue.r.Int()%2 == 1 {
+//		goto READ
+//	} else {
+//		goto WRITE
+//	}
+//
+//READ:
+//	// Read
+//	// Pop the front
+//	k, queue.q = queue.q[0], append([]int{}, queue.q[1:]...)
+//	return seqRequest{Tp: tpRead, K: k}
+//WRITE:
+//	// Write
+//	// Push the end
+//	queue.count++
+//	queue.q = append(queue.q, k)
+//	return seqRequest{Tp: tpWrite, K: k}
+//}
+//
+//// Create creates a new SequentialClient.
+//func (SequentialClientCreator) Create(node string) core.Client {
+//	return &sequentialClient{
+//		tableCount: 3,
+//		keyCount:   5,
+//		gen:        generator.Stagger(time.Millisecond*10, genRequest),
+//	}
+//}
+//
+//func (c *sequentialClient) tableNames() []string {
+//	names := make([]string, 0, c.tableCount)
+//	for i := 0; i < c.tableCount; i++ {
+//		names = append(names, fmt.Sprintf("%s%d", tablePrefix, i))
+//	}
+//	return names
+//}
+//
+//func subkeys(keyCount int, k int) []string {
+//	ks := make([]string, 0, keyCount)
+//	for i := 0; i < keyCount; i++ {
+//		ks = append(ks, fmt.Sprintf("%d_%d", k, i))
+//	}
+//	return ks
+//}
+//
+//func hash(s string) int {
+//	h := fnv.New32a()
+//	h.Write([]byte(s))
+//	return int(h.Sum32())
+//}
+//
+//func key2table(tableCount int, key string) string {
+//	return fmt.Sprintf("%s%d", tablePrefix, hash(key)%tableCount)
+//}
+//
+//// SetUp sets up the client.
+//func (c *sequentialClient) SetUp(ctx context.Context, nodes []string, node string) error {
+//	db, err := sql.Open("mysql", fmt.Sprintf("root@tcp(%s:4000)/test", node))
+//	if err != nil {
+//		return err
+//	}
+//	c.db = db
+//
+//	db.SetMaxIdleConns(1 + c.tableCount)
+//
+//	// Do SetUp in the first node
+//	if node != nodes[0] {
+//		return nil
+//	}
+//
+//	tableNames := c.tableNames()
+//	log.Printf("begin to create table %v on node %s", tableNames, node)
+//	for _, tableName := range tableNames {
+//		log.Printf("try to drop table %s", tableName)
+//		if _, err = db.ExecContext(ctx,
+//			fmt.Sprintf(" drop table if exists %s", tableName)); err != nil {
+//			return err
+//		}
+//		sql := `create table if not exists %s (tkey varchar(255) primary key)`
+//		if _, err = db.ExecContext(ctx, fmt.Sprintf(sql, tableName)); err != nil {
+//			return err
+//		}
+//		log.Printf("created table %s", tableName)
+//	}
+//
+//	return nil
+//}
+//
+//// TearDown tears down the client.
+//func (c *sequentialClient) TearDown(ctx context.Context, nodes []string, node string) error {
+//	return c.db.Close()
+//}
+//
+//// Invoke invokes a request to the database.
+//// Mostly, the return Response should implement UnknownResponse interface
+//func (c *sequentialClient) Invoke(ctx context.Context, node string, r interface{}) interface{} {
+//	req := r.(seqRequest)
+//	ks := subkeys(c.keyCount, req.K)
+//	if req.Tp == tpWrite {
+//		for _, k := range ks {
+//			sql := fmt.Sprintf("insert into %s values (?)", key2table(c.tableCount, k))
+//			_, err := c.db.ExecContext(ctx, sql, k)
+//			if err != nil {
+//				// TODO: retry on conflict
+//				log.Println(err)
+//				return seqResponse{Ok: false}
+//			}
+//		}
+//		return seqResponse{Ok: true}
+//	} else if req.Tp == tpRead {
+//		vs := make([]string, 0, len(ks))
+//		for i := len(ks) - 1; i >= 0; i-- {
+//			k := ks[i]
+//			sql := fmt.Sprintf("select tkey from %s where tkey = ?", key2table(c.tableCount, k))
+//			var v string
+//			err := c.db.QueryRowContext(ctx, sql, k).Scan(&v)
+//			if err != nil {
+//				// TODO: retry on conflict
+//				log.Println(err)
+//				return seqResponse{Ok: false}
+//			}
+//			vs = append(vs, v)
+//		}
+//		resp := seqResponse{
+//			Ok: true,
+//			K:  req.K,
+//			V:  vs,
+//		}
+//		return resp
+//	} else {
+//		panic(fmt.Sprintf("unknown req %v", req))
+//	}
+//}
+//
+//// NextRequest generates a request for latter Invoke.
+//func (c *sequentialClient) NextRequest() interface{} {
+//	return c.gen()
+//}
+//
+//// DumpState the database state(also the model's state)
+//func (c *sequentialClient) DumpState(ctx context.Context) (interface{}, error) {
+//	return nil, nil
+//}
+//
+//// NewSequentialChecker returns a new sequentialChecker.
+//func NewSequentialChecker() core.Checker {
+//	return sequentialChecker{}
+//}
+//
+//// sequentialChecker checks whether a history is sequential.
+//type sequentialChecker struct{}
+//
+//// Check checks the sequential history.
+//func (sequentialChecker) Check(_ core.Model, ops []core.Operation) (bool, error) {
+//	for _, op := range ops {
+//		if op.Action == core.ReturnOperation {
+//			resp := op.Data.(seqResponse)
+//			if !resp.Unknown && resp.Ok {
+//				foundNoneEmpty := false
+//				for _, s := range resp.V {
+//					if !foundNoneEmpty {
+//						foundNoneEmpty = s != ""
+//					} else if s == "" {
+//						log.Printf("Find no sequential op %+v", resp)
+//						return false, nil
+//					}
+//				}
+//			}
+//		}
+//	}
+//	return true, nil
+//}
+//
+//// Name returns the name of the verifier.
+//func (sequentialChecker) Name() string {
+//	return "sequential_checker"
+//}
+//
+//type parser struct{}
+//
+//// OnRequest impls history.RecordParser.OnRequest
+//func (p parser) OnRequest(data json.RawMessage) (interface{}, error) {
+//	r := seqRequest{}
+//	err := json.Unmarshal(data, &r)
+//	return r, err
+//}
+//
+//// OnResponse impls history.RecordParser.OnRequest
+//func (p parser) OnResponse(data json.RawMessage) (interface{}, error) {
+//	r := seqResponse{}
+//	err := json.Unmarshal(data, &r)
+//	if r.Unknown {
+//		return nil, err
+//	}
+//	return r, err
+//}
+//
+//// OnNoopResponse impls history.RecordParser.OnRequest
+//func (p parser) OnNoopResponse() interface{} {
+//	return seqResponse{Unknown: true}
+//}
+//
+//func (p parser) OnState(data json.RawMessage) (interface{}, error) {
+//	return nil, nil
+//}
+//
+//// NewSequentialParser returns a parser parses a history of bank operations.
+//func NewSequentialParser() history.RecordParser {
+//	return parser{}
+//}

--- a/db/tidb/sequential.go
+++ b/db/tidb/sequential.go
@@ -1,4 +1,5 @@
 package tidb
+
 //
 //import (
 //	"context"

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/cznic/sortutil v0.0.0-20150617083342-4c7342852e65/go.mod h1:q2w6Bg5je
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f h1:dDxpBYafY/GYpcl+LS4Bn3ziLPuEdGRkRjYAbSlWxSA=
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v0.0.0-20180421182945-02af3965c54e/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -103,11 +104,14 @@ github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTw
 github.com/pingcap/failpoint v0.0.0-20190512135322-30cc7431d99c/go.mod h1:DNS3Qg7bEDhU6EXNHF+XSv/PGznQaMJ5FWvctpm6pQI=
 github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
 github.com/pingcap/kvproto v0.0.0-20190516013202-4cf58ad90b6c/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
+github.com/pingcap/kvproto v0.0.0-20190703131923-d9830856b531 h1:8xk2HobDwClB5E3Hv9TEPiS7K7bv3ykWHLyZzuUYywI=
 github.com/pingcap/kvproto v0.0.0-20190703131923-d9830856b531/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
+github.com/pingcap/parser v0.0.0-20190708123555-29973f7a22eb h1:jfhJo/D1bWMF+zVaVdmixWG5EnxbnFt99GS2pdxuToo=
 github.com/pingcap/parser v0.0.0-20190708123555-29973f7a22eb/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v0.0.0-20190617100349-293d4b5189bf/go.mod h1:3DlDlFT7EF64A1bmb/tulZb6wbPSagm5G4p1AlhaEDs=
+github.com/pingcap/tidb v0.0.0-20190710093938-f409f0b4cfae h1:L9qCTwFq9HSMaqyIzvVvHw1U5halQODA4c47Q+w2Foc=
 github.com/pingcap/tidb v0.0.0-20190710093938-f409f0b4cfae/go.mod h1:AbcZH/h/d5kc7FzMUiE7+6WxynRnxAEpVVKxi0fx+a8=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
@@ -123,6 +127,7 @@ github.com/prometheus/common v0.0.0-20180518154759-7600349dcfe1/go.mod h1:daVV7q
 github.com/prometheus/common v0.0.0-20181020173914-7e9e6cabbd39/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20180612222113-7d6f385de8be/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/remyoudompheng/bigfft v0.0.0-20190512091148-babf20351dd7 h1:FUL3b97ZY2EPqg2NbXKuMHs5pXJB9hjj1fDHnF2vl28=
 github.com/remyoudompheng/bigfft v0.0.0-20190512091148-babf20351dd7/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v2.18.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/anishathalye/porcupine v0.0.0-20190205033716-f6fec466e840 h1:gBuqqvViM8SrAyILxx0Q6UIKK82O+As2brBdQT2TeoU=
 github.com/anishathalye/porcupine v0.0.0-20190205033716-f6fec466e840/go.mod h1:FTYUM6ZeF0TIVWODQgFV5mEwQLdfF2IiPICYgN+unJM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=

--- a/pkg/check/porcupine/porcupine.go
+++ b/pkg/check/porcupine/porcupine.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/anishathalye/porcupine"
+
 	"github.com/pingcap/tipocket/pkg/core"
 )
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"context"
-	"encoding/json"
 )
 
 // Node is the service endpoint in K8s, it's maybe podIP:port or CLUSTER-IP:port
@@ -19,7 +18,7 @@ type Node struct {
 // Provisioner provides a collection of APIs to deploy/destroy a cluster
 type Provisioner interface {
 	// SetUp sets up cluster, returns err or all nodes info
-	SetUp(ctx context.Context, spec json.RawMessage) (error, []Node)
+	SetUp(ctx context.Context, spec interface{}) (error, []Node)
 	// TearDown tears down the cluster
 	TearDown() error
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1,6 +1,9 @@
 package cluster
 
-import "encoding/json"
+import (
+	"context"
+	"encoding/json"
+)
 
 // Node is the service access point in K8s, it's maybe podIP:port or CLUSTER-IP:port
 type Node struct {
@@ -8,8 +11,10 @@ type Node struct {
 	Port string
 }
 
-// Provisioner provides APIs for deploy/destroy a cluster
+// Provisioner provides a collection of APIs to deploy/destroy a cluster
 type Provisioner interface {
-	Deploy(spec json.RawMessage) (error, []Node)
-	Destroy() error
+	// SetUp sets up cluster, returns err or all nodes info
+	SetUp(ctx context.Context, spec json.RawMessage) (error, []Node)
+	// TearDown tears down the cluster
+	TearDown() error
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -5,8 +5,13 @@ import (
 	"encoding/json"
 )
 
-// Node is the service access point in K8s, it's maybe podIP:port or CLUSTER-IP:port
+// Node is the service endpoint in K8s, it's maybe podIP:port or CLUSTER-IP:port
 type Node struct {
+	// Cluster k8s' namespace
+	Namespace string
+	// Pod's name
+	PodName string
+
 	IP   string
 	Port string
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1,0 +1,15 @@
+package cluster
+
+import "encoding/json"
+
+// Node is the service access point in K8s, it's maybe podIP:port or CLUSTER-IP:port
+type Node struct {
+	IP   string
+	Port string
+}
+
+// Provisioner provides APIs for deploy/destroy a cluster
+type Provisioner interface {
+	Deploy(spec json.RawMessage) (error, []Node)
+	Destroy() error
+}

--- a/pkg/control/config.go
+++ b/pkg/control/config.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"github.com/pingcap/tipocket/pkg/cluster"
 	"time"
 )
 
@@ -9,7 +10,7 @@ type Config struct {
 	// DB is the name which we want to run.
 	DB string
 	// Nodes are address of nodes.
-	Nodes []string
+	Nodes []cluster.Node
 
 	// RunRound controls how many round the controller runs tests.
 	RunRound int

--- a/pkg/control/config.go
+++ b/pkg/control/config.go
@@ -1,8 +1,9 @@
 package control
 
 import (
-	"github.com/pingcap/tipocket/pkg/cluster"
 	"time"
+
+	"github.com/pingcap/tipocket/pkg/cluster"
 )
 
 // Config is the configuration for the controller.

--- a/pkg/core/client.go
+++ b/pkg/core/client.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"github.com/pingcap/tipocket/pkg/cluster"
 )
 
 // UnknownResponse means we don't know wether this operation
@@ -15,12 +16,12 @@ type UnknownResponse interface {
 // You should define your own client for your database.
 type Client interface {
 	// SetUp sets up the client.
-	SetUp(ctx context.Context, nodes []string, node string) error
+	SetUp(ctx context.Context, nodes []cluster.Node, node cluster.Node) error
 	// TearDown tears down the client.
-	TearDown(ctx context.Context, nodes []string, node string) error
+	TearDown(ctx context.Context, nodes []cluster.Node, node cluster.Node) error
 	// Invoke invokes a request to the database.
 	// Mostly, the return Response should implement UnknownResponse interface
-	Invoke(ctx context.Context, node string, r interface{}) interface{}
+	Invoke(ctx context.Context, node cluster.Node, r interface{}) interface{}
 	// NextRequest generates a request for latter Invoke.
 	NextRequest() interface{}
 	// DumpState the database state(also the model's state)
@@ -31,7 +32,7 @@ type Client interface {
 // The control will create one client for one node.
 type ClientCreator interface {
 	// Create creates the client.
-	Create(node string) Client
+	Create(node cluster.Node) Client
 }
 
 // NoopClientCreator creates a noop client.
@@ -48,13 +49,13 @@ type noopClient struct {
 }
 
 // SetUp sets up the client.
-func (noopClient) SetUp(ctx context.Context, nodes []string, node string) error { return nil }
+func (noopClient) SetUp(ctx context.Context, nodes []cluster.Node, node cluster.Node) error { return nil }
 
 // TearDown tears down the client.
-func (noopClient) TearDown(ctx context.Context, nodes []string, node string) error { return nil }
+func (noopClient) TearDown(ctx context.Context, nodes []cluster.Node, node cluster.Node) error { return nil }
 
 // Invoke invokes a request to the database.
-func (noopClient) Invoke(ctx context.Context, node string, r interface{}) interface{} {
+func (noopClient) Invoke(ctx context.Context, node cluster.Node, r interface{}) interface{} {
 	return nil
 }
 

--- a/pkg/core/client.go
+++ b/pkg/core/client.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+
 	"github.com/pingcap/tipocket/pkg/cluster"
 )
 
@@ -49,10 +50,14 @@ type noopClient struct {
 }
 
 // SetUp sets up the client.
-func (noopClient) SetUp(ctx context.Context, nodes []cluster.Node, node cluster.Node) error { return nil }
+func (noopClient) SetUp(ctx context.Context, nodes []cluster.Node, node cluster.Node) error {
+	return nil
+}
 
 // TearDown tears down the client.
-func (noopClient) TearDown(ctx context.Context, nodes []cluster.Node, node cluster.Node) error { return nil }
+func (noopClient) TearDown(ctx context.Context, nodes []cluster.Node, node cluster.Node) error {
+	return nil
+}
 
 // Invoke invokes a request to the database.
 func (noopClient) Invoke(ctx context.Context, node cluster.Node, r interface{}) interface{} {

--- a/pkg/core/db.go
+++ b/pkg/core/db.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+
 	"github.com/pingcap/tipocket/pkg/cluster"
 )
 

--- a/pkg/core/db.go
+++ b/pkg/core/db.go
@@ -3,22 +3,23 @@ package core
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/tipocket/pkg/cluster"
 )
 
 // DB allows Chaos to set up and tear down database.
 type DB interface {
 	// SetUp initializes the database.
-	SetUp(ctx context.Context, nodes []string, node string) error
+	SetUp(ctx context.Context, nodes []cluster.Node, node cluster.Node) error
 	// TearDown tears down the database.
-	TearDown(ctx context.Context, nodes []string, node string) error
+	TearDown(ctx context.Context, nodes []cluster.Node, node cluster.Node) error
 	// Start starts the database
-	Start(ctx context.Context, node string) error
+	Start(ctx context.Context, node cluster.Node) error
 	// Stop stops the database
-	Stop(ctx context.Context, node string) error
+	Stop(ctx context.Context, node cluster.Node) error
 	// Kill kills the database
-	Kill(ctx context.Context, node string) error
+	Kill(ctx context.Context, node cluster.Node) error
 	// IsRunning checks whether the database is running or not
-	IsRunning(ctx context.Context, node string) bool
+	IsRunning(ctx context.Context, node cluster.Node) bool
 	// Name returns the unique name for the database
 	Name() string
 }
@@ -28,32 +29,32 @@ type NoopDB struct {
 }
 
 // SetUp initializes the database.
-func (NoopDB) SetUp(ctx context.Context, nodes []string, node string) error {
+func (NoopDB) SetUp(ctx context.Context, nodes []cluster.Node, node cluster.Node) error {
 	return nil
 }
 
 // TearDown tears down the datase.
-func (NoopDB) TearDown(ctx context.Context, nodes []string, node string) error {
+func (NoopDB) TearDown(ctx context.Context, nodes []cluster.Node, node cluster.Node) error {
 	return nil
 }
 
 // Start starts the database
-func (NoopDB) Start(ctx context.Context, node string) error {
+func (NoopDB) Start(ctx context.Context, node cluster.Node) error {
 	return nil
 }
 
 // Stop stops the database
-func (NoopDB) Stop(ctx context.Context, node string) error {
+func (NoopDB) Stop(ctx context.Context, node cluster.Node) error {
 	return nil
 }
 
 // Kill kills the database
-func (NoopDB) Kill(ctx context.Context, node string) error {
+func (NoopDB) Kill(ctx context.Context, node cluster.Node) error {
 	return nil
 }
 
 // IsRunning checks whether the database is running or not
-func (NoopDB) IsRunning(ctx context.Context, node string) bool {
+func (NoopDB) IsRunning(ctx context.Context, node cluster.Node) bool {
 	return true
 }
 

--- a/pkg/core/nemesis.go
+++ b/pkg/core/nemesis.go
@@ -3,8 +3,9 @@ package core
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tipocket/pkg/cluster"
 	"time"
+
+	"github.com/pingcap/tipocket/pkg/cluster"
 )
 
 // Nemesis injects failure and disturbs the database.

--- a/pkg/core/nemesis.go
+++ b/pkg/core/nemesis.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/tipocket/pkg/cluster"
 	"time"
 )
 
@@ -14,9 +15,9 @@ type Nemesis interface {
 	// TearDown(ctx context.Context, node string) error
 
 	// Invoke executes the nemesis
-	Invoke(ctx context.Context, node string, args ...string) error
+	Invoke(ctx context.Context, node cluster.Node, args ...string) error
 	// Recover recovers the nemesis
-	Recover(ctx context.Context, node string, args ...string) error
+	Recover(ctx context.Context, node cluster.Node, args ...string) error
 	// Name returns the unique name for the nemesis
 	Name() string
 }
@@ -36,12 +37,12 @@ type NoopNemesis struct {
 // }
 
 // Invoke executes the nemesis
-func (NoopNemesis) Invoke(ctx context.Context, node string, args ...string) error {
+func (NoopNemesis) Invoke(ctx context.Context, node cluster.Node, args ...string) error {
 	return nil
 }
 
 // Recover recovers the nemesis
-func (NoopNemesis) Recover(ctx context.Context, node string, args ...string) error {
+func (NoopNemesis) Recover(ctx context.Context, node cluster.Node, args ...string) error {
 	return nil
 }
 
@@ -85,7 +86,7 @@ type NemesisOperation struct {
 type NemesisGenerator interface {
 	// Generate generates the nemesis operation for all nodes.
 	// Every node will be assigned a nemesis operation.
-	Generate(nodes []string) []*NemesisOperation
+	Generate(nodes []cluster.Node) []*NemesisOperation
 	Name() string
 }
 

--- a/pkg/model/cas_register_test.go
+++ b/pkg/model/cas_register_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/anishathalye/porcupine"
+
 	"github.com/pingcap/tipocket/pkg/core"
 )
 

--- a/pkg/nemesis/generator.go
+++ b/pkg/nemesis/generator.go
@@ -1,9 +1,10 @@
 package nemesis
 
 import (
-	"github.com/pingcap/tipocket/pkg/cluster"
 	"math/rand"
 	"time"
+
+	"github.com/pingcap/tipocket/pkg/cluster"
 
 	"github.com/pingcap/tipocket/pkg/core"
 )

--- a/pkg/nemesis/generator.go
+++ b/pkg/nemesis/generator.go
@@ -1,6 +1,7 @@
 package nemesis
 
 import (
+	"github.com/pingcap/tipocket/pkg/cluster"
 	"math/rand"
 	"time"
 
@@ -12,7 +13,7 @@ type killGenerator struct {
 	name string
 }
 
-func (g killGenerator) Generate(nodes []string) []*core.NemesisOperation {
+func (g killGenerator) Generate(nodes []cluster.Node) []*core.NemesisOperation {
 	n := 1
 	switch g.name {
 	case "minor_kill":
@@ -32,7 +33,7 @@ func (g killGenerator) Name() string {
 	return g.name
 }
 
-func killNodes(db string, nodes []string, n int) []*core.NemesisOperation {
+func killNodes(db string, nodes []cluster.Node, n int) []*core.NemesisOperation {
 	ops := make([]*core.NemesisOperation, len(nodes))
 
 	// randomly shuffle the indecies and get the first n nodes to be partitioned.
@@ -60,7 +61,7 @@ type dropGenerator struct {
 	name string
 }
 
-func (g dropGenerator) Generate(nodes []string) []*core.NemesisOperation {
+func (g dropGenerator) Generate(nodes []cluster.Node) []*core.NemesisOperation {
 	n := 1
 	switch g.name {
 	case "minor_drop":
@@ -79,7 +80,7 @@ func (g dropGenerator) Name() string {
 	return g.name
 }
 
-func partitionNodes(nodes []string, n int) []*core.NemesisOperation {
+func partitionNodes(nodes []cluster.Node, n int) []*core.NemesisOperation {
 	ops := make([]*core.NemesisOperation, len(nodes))
 
 	// randomly shuffle the indecies and get the first n nodes to be partitioned.
@@ -87,7 +88,7 @@ func partitionNodes(nodes []string, n int) []*core.NemesisOperation {
 
 	partNodes := make([]string, n)
 	for i := 0; i < n; i++ {
-		partNodes[i] = nodes[indices[i]]
+		partNodes[i] = nodes[indices[i]].IP
 	}
 
 	for i := 0; i < len(nodes); i++ {

--- a/pkg/nemesis/nemesis.go
+++ b/pkg/nemesis/nemesis.go
@@ -2,6 +2,7 @@ package nemesis
 
 import (
 	"context"
+
 	"github.com/pingcap/tipocket/pkg/cluster"
 
 	"github.com/pingcap/tipocket/pkg/core"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,12 +3,13 @@ package util
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tipocket/pkg/cluster"
 	"net/url"
 	"path"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/pingcap/tipocket/pkg/cluster"
 
 	"github.com/pingcap/tipocket/pkg/util/ssh"
 )

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/tipocket/pkg/cluster"
 	"net/url"
 	"path"
 	"path/filepath"
@@ -189,8 +190,8 @@ func StopDaemon(ctx context.Context, node string, cmd string, pidFile string) er
 }
 
 // KillDaemon runs on node and kills the daemon process.
-func KillDaemon(ctx context.Context, node string, cmd string, pidFile string) error {
-	return stopDaemon(ctx, node, cmd, pidFile, "KILL")
+func KillDaemon(ctx context.Context, node cluster.Node, cmd string, pidFile string) error {
+	return stopDaemon(ctx, node.IP, cmd, pidFile, "KILL")
 }
 
 func stopDaemon(ctx context.Context, node string, cmd string, pidFile string, sig string) error {


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

### What is changed and how does it work?

- [x] Extract cluster `provisioner` interface as the adapter of cluster manager on K8s.
- ~~[ ] Refactor the `Nemesis` interface~~

To retain the backward compatibility, I extract out a `Node` struct and denotes a Pod on K8s environment.

That's means we cannot inject pod-kill kind faults using chaos-mesh currently, because they destroy the Pod and make the related `Node` be illegal. we need resolve this limitation in the future.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
