### PR TITLE
k8s cluster: Support tidb monitor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,10 @@ COPY . .
 
 RUN make build
 
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+FROM alpine:3.8
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash curl wget
-RUN gcloud components install kubectl
 
 COPY --from=0 /src/bin/* /bin/
 

--- a/pkg/cluster/k8s.go
+++ b/pkg/cluster/k8s.go
@@ -75,6 +75,11 @@ func (k *K8sProvisioner) setUpTiDBCluster(recommend *tidb.TiDBClusterRecommendat
 		return nodes, clientNodes, err
 	}
 
+	err = k.TestCli.TiDB.ApplyTiDBMonitor(recommend.TidbMonitor)
+	if err != nil {
+		return nodes, clientNodes, err
+	}
+
 	nodes, err = k.TestCli.TiDB.GetNodes(recommend)
 	if err != nil {
 		return nodes, clientNodes, err
@@ -121,7 +126,7 @@ func (k *K8sProvisioner) tearDownTiDBCluster(recommend *tidb.TiDBClusterRecommen
 		return err
 	}
 	if fixture.Context.PurgeNsOnSuccess {
-		return k.TestCli.DeleteNamespace(recommend.Name)
+		return k.TestCli.DeleteNamespace(recommend.Namespace)
 	}
 	return nil
 }

--- a/pkg/cluster/k8s.go
+++ b/pkg/cluster/k8s.go
@@ -75,6 +75,7 @@ func (k *K8sProvisioner) setUpTiDBCluster(recommend *tidb.TiDBClusterRecommendat
 		return nodes, clientNodes, err
 	}
 
+	// TODO: maybe we need wait tidb monitor ready here?
 	err = k.TestCli.TiDB.ApplyTiDBMonitor(recommend.TidbMonitor)
 	if err != nil {
 		return nodes, clientNodes, err
@@ -122,6 +123,9 @@ func (k *K8sProvisioner) setUpBinlogCluster(recommend *binlog.ClusterRecommendat
 }
 
 func (k *K8sProvisioner) tearDownTiDBCluster(recommend *tidb.TiDBClusterRecommendation) error {
+	if err := k.TestCli.TiDB.DeleteTiDBMonitor(recommend.TidbMonitor); err != nil {
+		return err
+	}
 	if err := k.TestCli.TiDB.DeleteTiDBCluster(recommend.TidbCluster); err != nil {
 		return err
 	}

--- a/pkg/test-infra/fixture/fixture.go
+++ b/pkg/test-infra/fixture/fixture.go
@@ -45,6 +45,7 @@ type fixtureContext struct {
 	PurgeNsOnSuccess         bool
 	BinlogConfig             BinlogConfig
 	LocalVolumeStorageClass  string
+	TiDBMonitorSvcType       string
 	RemoteVolumeStorageClass string
 	TiDBVersion              string
 	MySQLVersion             string
@@ -151,6 +152,7 @@ func init() {
 	flag.StringVar(&Context.HubAddress, "hub", "", "hub address, default to docker hub")
 	flag.StringVar(&Context.ImageVersion, "image-version", "latest", "image version")
 	flag.StringVar(&Context.LocalVolumeStorageClass, "storage-class", "local-storage", "storage class name")
+	flag.StringVar(&Context.TiDBMonitorSvcType, "monitor-svc", "ClusterIP", "TiDB monitor service type")
 	flag.StringVar(&Context.pprofAddr, "pprof", "0.0.0.0:8080", "Pprof address")
 	flag.StringVar(&Context.BinlogConfig.BinlogVersion, "binlog-version", "", `overwrite "-image-version" flag for drainer`)
 	flag.BoolVar(&Context.BinlogConfig.EnableRelayLog, "relay-log", false, "if enable relay log")

--- a/pkg/test-infra/tidb/operation.go
+++ b/pkg/test-infra/tidb/operation.go
@@ -237,6 +237,17 @@ func (t *TidbOps) WaitTiDBClusterReady(tc *v1alpha1.TidbCluster, timeout time.Du
 	})
 }
 
+func (t *TidbOps) ApplyTiDBMonitor(tm *v1alpha1.TidbMonitor) error {
+	desired := tm.DeepCopy()
+	_, err := controllerutil.CreateOrUpdate(context.TODO(), t.cli, tm, func() error {
+		tm.Spec = desired.Spec
+		tm.Annotations = desired.Annotations
+		tm.Labels = desired.Labels
+		return nil
+	})
+	return err
+}
+
 func (t *TidbOps) DeleteTiDBCluster(tc *v1alpha1.TidbCluster) error {
 	return t.cli.Delete(context.TODO(), tc)
 }

--- a/pkg/test-infra/tidb/operation.go
+++ b/pkg/test-infra/tidb/operation.go
@@ -252,6 +252,10 @@ func (t *TidbOps) DeleteTiDBCluster(tc *v1alpha1.TidbCluster) error {
 	return t.cli.Delete(context.TODO(), tc)
 }
 
+func (t *TidbOps) DeleteTiDBMonitor(tm *v1alpha1.TidbMonitor) error {
+	return t.cli.Delete(context.TODO(), tm)
+}
+
 func (t *TidbOps) ApplyTiDBConfigMap(tc *v1alpha1.TidbCluster) error {
 	configMap, err := getTiDBConfigMap(tc)
 	if err != nil {

--- a/pkg/test-infra/tidb/recommend.go
+++ b/pkg/test-infra/tidb/recommend.go
@@ -175,7 +175,7 @@ func RecommendedTiDBCluster(ns, name string) *TiDBClusterRecommendation {
 						Version:   "v1.0.1",
 					},
 				},
-				ImagePullPolicy: corev1.PullAlways,
+				ImagePullPolicy: corev1.PullIfNotPresent,
 			},
 		},
 		Service: &corev1.Service{


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Need to create a TiDB monitor when create the TiDB cluster.

On GKE, I found a problem that when I use LoadBalancer as the Grafana service type, the NodePort is always changing, and the Grafana dashboard isn't accessible. Maybe refs: https://github.com/pingcap/tidb-operator/issues/1949

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
