### PR TITLE
support tidb/tikv/pd configmap as arguments

### DIFF
--- a/pkg/test-infra/fixture/fixture.go
+++ b/pkg/test-infra/fixture/fixture.go
@@ -53,6 +53,9 @@ type fixtureContext struct {
 	HubAddress               string
 	DockerRepository         string
 	ImageVersion             string
+	TiDBConfigMap            string
+	TiKVConfigMap            string
+	PDConfigMap              string
 	// Loki
 	LokiAddress  string
 	LokiUsername string
@@ -155,6 +158,9 @@ func init() {
 	flag.StringVar(&Context.Namespace, "namespace", "", "test namespace")
 	flag.StringVar(&Context.HubAddress, "hub", "", "hub address, default to docker hub")
 	flag.StringVar(&Context.ImageVersion, "image-version", "latest", "image version")
+	flag.StringVar(&Context.TiDBConfigMap, "tidb-configmap", "", "path of tidb configmap")
+	flag.StringVar(&Context.TiKVConfigMap, "tikv-configmap", "", "path of tikv configmap")
+	flag.StringVar(&Context.PDConfigMap, "pd-configmap", "", "path of pd configmap")
 	flag.StringVar(&Context.LocalVolumeStorageClass, "storage-class", "local-storage", "storage class name")
 	flag.StringVar(&Context.TiDBMonitorSvcType, "monitor-svc", "ClusterIP", "TiDB monitor service type")
 	flag.StringVar(&Context.pprofAddr, "pprof", "0.0.0.0:8080", "Pprof address")

--- a/pkg/test-infra/tidb/operation.go
+++ b/pkg/test-infra/tidb/operation.go
@@ -16,6 +16,7 @@ package tidb
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"strings"
 	"time"
 
@@ -439,9 +440,24 @@ func getTidbDiscoveryService(tc *v1alpha1.TidbCluster) *corev1.Service {
 	}
 }
 
+func readFileAsString(filename string) (string, error) {
+	if filename == "" {
+		return ``, nil
+	}
+	if bytes, err := ioutil.ReadFile(filename); err != nil {
+		return ``, err
+	} else {
+		return string(bytes), nil
+	}
+}
+
 // TODO: use the latest tidb-operator feature instead
 func getPDConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 	s, err := RenderPDStartScript(&PDStartScriptModel{})
+	if err != nil {
+		return nil, err
+	}
+	configFile, err := readFileAsString(fixture.Context.PDConfigMap)
 	if err != nil {
 		return nil, err
 	}
@@ -452,13 +468,17 @@ func getPDConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 		},
 		Data: map[string]string{
 			"startup-script": s,
-			"config-file":    ``,
+			"config-file":    configFile,
 		},
 	}, nil
 }
 
 func getTiDBConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 	s, err := RenderTiDBStartScript(&TidbStartScriptModel{ClusterName: tc.Name})
+	if err != nil {
+		return nil, err
+	}
+	configFile, err := readFileAsString(fixture.Context.TiDBConfigMap)
 	if err != nil {
 		return nil, err
 	}
@@ -469,13 +489,17 @@ func getTiDBConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 		},
 		Data: map[string]string{
 			"startup-script": s,
-			"config-file":    ``,
+			"config-file":    configFile,
 		},
 	}, nil
 }
 
 func getTiKVConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 	s, err := RenderTiKVStartScript(&TiKVStartScriptModel{})
+	if err != nil {
+		return nil, err
+	}
+	configFile, err := readFileAsString(fixture.Context.TiKVConfigMap)
 	if err != nil {
 		return nil, err
 	}
@@ -486,7 +510,7 @@ func getTiKVConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 		},
 		Data: map[string]string{
 			"startup-script": s,
-			"config-file":    ``,
+			"config-file":    configFile,
 		},
 	}, nil
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->
Be able to choose a configmap for tidb/tikv/pd cluster
### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
