### PR TITLE
bug fix: pdChaos panic

### DIFF
--- a/argo/template/abtest.yaml
+++ b/argo/template/abtest.yaml
@@ -1,0 +1,34 @@
+metadata:
+  name: tipocket-abtest
+  namespace: argo
+spec:
+  templates:
+    - name: tipocket-abtest
+      inputs:
+        parameters:
+          - name: ns
+            default: tipocket-abtest
+          - name: image_version
+            default: latest
+          - name: storage_class
+            default: pd-ssd
+          - name: b_version
+            default: nightly
+      container:
+        name: tipocket
+        image: 'pingcap/tipocket:latest'
+        command:
+          - sh
+          - '-c'
+          - |
+            /bin/abtest \
+            -namespace={{inputs.parameters.ns}} \
+            -hub=docker.io \
+            -storage-class={{inputs.parameters.storage_class}} \
+            -image-version={{inputs.parameters.image_version}} \
+            -abtest.b.version={{inputs.parameters.b_version}} \
+            -purge=true \
+            -client=2
+      retryStrategy:
+        limit: 0
+        retryPolicy: Always

--- a/pkg/cluster/types/cluster.go
+++ b/pkg/cluster/types/cluster.go
@@ -28,11 +28,12 @@ const (
 // Client provides useful methods about cluster
 type Client struct {
 	Namespace    string
-	PDMemberFunc func(ns string) (string, []string, error)
+	ClusterName  string
+	PDMemberFunc func(ns, name string) (string, []string, error)
 }
 
 func (c *Client) PDMember() (string, []string, error) {
-	return c.PDMemberFunc(c.Namespace)
+	return c.PDMemberFunc(c.Namespace, c.ClusterName)
 }
 
 // Node is the cluster endpoint in K8s, it's maybe podIP:port or CLUSTER-IP:port

--- a/pkg/test-infra/tidb/operation.go
+++ b/pkg/test-infra/tidb/operation.go
@@ -602,9 +602,10 @@ func (t *TidbOps) parseNodeFromPodList(pods *corev1.PodList) []clusterTypes.Node
 			Component: clusterTypes.Component(component),
 			Port:      util.FindPort(pod.ObjectMeta.Name, pod.Spec.Containers[0].Ports),
 			Client: &clusterTypes.Client{
-				Namespace: pod.ObjectMeta.Namespace,
-				PDMemberFunc: func(ns string) (string, []string, error) {
-					return t.GetPDMember(ns, ns)
+				Namespace:   pod.ObjectMeta.Namespace,
+				ClusterName: pod.ObjectMeta.Labels["app.kubernetes.io/instance"],
+				PDMemberFunc: func(ns, name string) (string, []string, error) {
+					return t.GetPDMember(ns, name)
 				},
 			},
 		})


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

On ABTest cluster, the tidbcluster crd name isn't equal to the namespace name, so when inject a PD chaos, nemesis would throw a panic when it cannot find the tidbcluster according to the namespace name.

```log
2020-03-20 14:21:39.058328 I | begin to run short_kill_pd_leader nemesis generator

2020-03-20 14:21:39.061322 I | find pd members occured an error: tidbclusters.pingcap.com "tipocket-abtest" not found
```

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
