### PR TITLE
Add failover count limit

### DIFF
--- a/pkg/test-infra/abtest/recommand.go
+++ b/pkg/test-infra/abtest/recommand.go
@@ -29,7 +29,7 @@ type Recommendation struct {
 	Name     string
 }
 
-// RecommendedCluster gives recommand cluster
+// RecommendedCluster gives a recommend cluster
 func RecommendedCluster(ns, name string) *Recommendation {
 	r := Recommendation{
 		Cluster1: tidb.RecommendedTiDBCluster(ns, fmt.Sprintf("%s-a", name)),

--- a/pkg/test-infra/tidb/recommend.go
+++ b/pkg/test-infra/tidb/recommend.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+	"k8s.io/utils/pointer"
 
 	"github.com/pingcap/tipocket/pkg/test-infra/fixture"
 
@@ -109,6 +110,7 @@ func RecommendedTiDBCluster(ns, name string) *Recommendation {
 					Replicas:             3,
 					ResourceRequirements: fixture.WithStorage(fixture.Medium, "10Gi"),
 					StorageClassName:     &fixture.Context.LocalVolumeStorageClass,
+					MaxFailoverCount:     pointer.Int32Ptr(3),
 					ComponentSpec: v1alpha1.ComponentSpec{
 						Version: &fixture.Context.ImageVersion,
 						Image:   buildImage("tikv"),
@@ -123,6 +125,7 @@ func RecommendedTiDBCluster(ns, name string) *Recommendation {
 						},
 						ExposeStatus: &exposeStatus,
 					},
+					MaxFailoverCount: pointer.Int32Ptr(3),
 					ComponentSpec: v1alpha1.ComponentSpec{
 						Version: &fixture.Context.ImageVersion,
 						Image:   buildImage("tidb"),


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

As per discuss offline, we need to limit the tikv and tidb failover count to 3.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
