### PR TITLE
*: add more information on clientNode

### DIFF
--- a/pkg/cluster/types/cluster.go
+++ b/pkg/cluster/types/cluster.go
@@ -49,10 +49,11 @@ type Node struct {
 
 // ClientNode is TiDB's exposed endpoint, can be a nodeport, or downgrade cluster ip
 type ClientNode struct {
-	Namespace string // Cluster k8s' namespace
-	Component Component
-	IP        string
-	Port      int32
+	Namespace   string // Cluster k8s' namespace
+	ClusterName string // Cluster name, use to differentiate different TiDB clusters running on same namespace
+	Component   Component
+	IP          string
+	Port        int32
 }
 
 // Provisioner provides a collection of APIs to deploy/destroy a cluster

--- a/pkg/test-infra/tidb/operation.go
+++ b/pkg/test-infra/tidb/operation.go
@@ -158,9 +158,10 @@ func (t *TidbOps) GetClientNodes(tc *Recommendation) ([]clusterTypes.ClientNode,
 		return clientNodes, err
 	}
 	clientNodes = append(clientNodes, clusterTypes.ClientNode{
-		Namespace: svc.ObjectMeta.Namespace,
-		IP:        ip,
-		Port:      getTiDBNodePort(svc),
+		Namespace:   svc.ObjectMeta.Namespace,
+		ClusterName: svc.ObjectMeta.Labels["app.kubernetes.io/instance"],
+		IP:          ip,
+		Port:        getTiDBNodePort(svc),
 	})
 	return clientNodes, nil
 }


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

When we know the client clusterName, we can access other component through DNS address easily.

For example, on https://github.com/pingcap/tipocket/pull/112, we can build the PD address using clusterName and namespace name.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
