### PR TITLE
a/b test: add abtest concurrency argument

### DIFF
--- a/cmd/abtest/main.go
+++ b/cmd/abtest/main.go
@@ -42,6 +42,7 @@ func main() {
 	pocketConfig := config.Init()
 	pocketConfig.Options.Serialize = true
 	pocketConfig.Options.Path = fixture.Context.ABTestConfig.LogPath
+	pocketConfig.Options.Concurrency = fixture.Context.ABTestConfig.Concurrency
 	suit := util.Suit{
 		Config:      &cfg,
 		Provisioner: cluster.NewK8sProvisioner(),

--- a/pkg/test-infra/fixture/abtest.go
+++ b/pkg/test-infra/fixture/abtest.go
@@ -21,4 +21,5 @@ type ABTestConfig struct {
 	Cluster1Version string
 	Cluster2Version string
 	LogPath         string
+	Concurrency     int
 }

--- a/pkg/test-infra/fixture/fixture.go
+++ b/pkg/test-infra/fixture/fixture.go
@@ -179,6 +179,7 @@ func init() {
 	flag.StringVar(&Context.ABTestConfig.PDConfigFile, "abtest.pd-config", "", "pd config file for cluster B")
 	flag.StringVar(&Context.ABTestConfig.Cluster2Version, "abtest.image-version", "", "specify version for cluster B")
 	flag.StringVar(&Context.ABTestConfig.LogPath, "abtest.log", "", "log path for abtest, default to stdout")
+	flag.IntVar(&Context.ABTestConfig.Concurrency, "abtest.concurrency", 3, "test concurrency, parallel session number")
 
 	Context.DockerRepository = "pingcap"
 


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Add an argument to control a/b test concurrency.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
