### PR TITLE
Refactor argo templates and workflows

### DIFF
--- a/argo/template/abtest.yaml
+++ b/argo/template/abtest.yaml
@@ -34,6 +34,12 @@ spec:
             default: ""
           - name: abtest_pd_config
             default: ""
+          - name: loki-addr
+            default: http://gateway.loki.svc
+          - name: loki-username
+            default: loki
+          - name: loki-password
+            default: admin
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'
@@ -57,9 +63,6 @@ spec:
             -abtest.tidb-config={{inputs.parameters.abtest_tidb_config}} \
             -abtest.tikv-config={{inputs.parameters.abtest_tikv_config}} \
             -abtest.pd-config={{inputs.parameters.abtest_pd_config}} \
-            -loki-addr=http://gateway.loki.svc \
-            -loki-username=loki \
-            -loki-password=admin
-      retryStrategy:
-        limit: 0
-        retryPolicy: Always
+            -loki-addr={{inputs.parameters.loki-addr}} \
+            -loki-username={{inputs.parameters.loki-username}} \
+            -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/abtest.yaml
+++ b/argo/template/abtest.yaml
@@ -55,7 +55,7 @@ spec:
             -abtest.image-version={{inputs.parameters.abtest_version}} \
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
-            -client=2 \
+            -client={{inputs.parameters.client}} \
             -run-time={{inputs.parameters.run_time}} \
             -tidb-config={{inputs.parameters.tidb_config}} \
             -tikv-config={{inputs.parameters.tikv_config}} \

--- a/argo/template/bank-iochaos.yaml
+++ b/argo/template/bank-iochaos.yaml
@@ -22,6 +22,12 @@ spec:
             default: "10000"
           - name: round
             default: "100"
+          - name: loki-addr
+            default: http://gateway.loki.svc
+          - name: loki-username
+            default: loki
+          - name: loki-password
+            default: admin
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'
@@ -40,9 +46,6 @@ spec:
             -nemesis={{inputs.parameters.nemesis}} \
             -round={{inputs.parameters.round}} \
             -request-count={{inputs.parameters.request_count}} \
-            -loki-addr=http://gateway.loki.svc \
-            -loki-username=loki \
-            -loki-password=admin
-      retryStrategy:
-        limit: 0
-        retryPolicy: Always
+            -loki-addr={{inputs.parameters.loki-addr}} \
+            -loki-username={{inputs.parameters.loki-username}} \
+            -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/bank.yaml
+++ b/argo/template/bank.yaml
@@ -22,6 +22,12 @@ spec:
             default: "10000"
           - name: round
             default: "100"
+          - name: loki-addr
+            default: http://gateway.loki.svc
+          - name: loki-username
+            default: loki
+          - name: loki-password
+            default: admin
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'
@@ -40,9 +46,6 @@ spec:
             -nemesis={{inputs.parameters.nemesis}} \
             -round={{inputs.parameters.round}} \
             -request-count={{inputs.parameters.request_count}} \
-            -loki-addr=http://gateway.loki.svc \
-            -loki-username=loki \
-            -loki-password=admin
-      retryStrategy:
-        limit: 0
-        retryPolicy: Always
+            -loki-addr={{inputs.parameters.loki-addr}} \
+            -loki-username={{inputs.parameters.loki-username}} \
+            -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/binlog.yaml
+++ b/argo/template/binlog.yaml
@@ -20,6 +20,12 @@ spec:
             default: "48h"
           - name: relay_log
             default: "true"
+          - name: loki-addr
+            default: http://gateway.loki.svc
+          - name: loki-username
+            default: loki
+          - name: loki-password
+            default: admin
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'
@@ -36,9 +42,6 @@ spec:
             -nemesis={{inputs.parameters.nemesis}} \
             -run-time={{inputs.parameters.run_time}} \
             -relay-log={{inputs.parameters.relay_log}} \
-            -loki-addr=http://gateway.loki.svc \
-            -loki-username=loki \
-            -loki-password=admin
-      retryStrategy:
-        limit: 0
-        retryPolicy: Always
+            -loki-addr={{inputs.parameters.loki-addr}} \
+            -loki-username={{inputs.parameters.loki-username}} \
+            -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/block-writer.yaml
+++ b/argo/template/block-writer.yaml
@@ -18,6 +18,12 @@ spec:
             default: ""
           - name: run_time
             default: "60m"
+          - name: loki-addr
+            default: http://gateway.loki.svc
+          - name: loki-username
+            default: loki
+          - name: loki-password
+            default: admin
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'
@@ -33,9 +39,6 @@ spec:
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
             -run-time={{inputs.parameters.run_time}} \
-            -loki-addr=http://gateway.loki.svc \
-            -loki-username=loki \
-            -loki-password=admin
-      retryStrategy:
-        limit: 0
-        retryPolicy: Always
+            -loki-addr={{inputs.parameters.loki-addr}} \
+            -loki-username={{inputs.parameters.loki-username}} \
+            -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/export-logs.yaml
+++ b/argo/template/export-logs.yaml
@@ -9,6 +9,12 @@ spec:
           - name: ns
           - name: limit
             default: 2000000
+          - name: loki-addr
+            default: http://gateway.loki.svc
+          - name: loki-username
+            default: loki
+          - name: loki-password
+            default: admin
       container:
         name: upload-logs
         workingDir: /src/tidb-logs
@@ -27,8 +33,9 @@ spec:
             for pod in $pods
             do
                echo $pod
-               logcli query -q -o raw --forward --no-labels --addr="http://gateway.loki.svc" \
-               --username=loki --password=admin  --from=$start --limit={{inputs.parameters.limit}} \
+               logcli query -q -o raw --forward --no-labels --addr="{{inputs.parameters.loki-addr}}" \
+               --username={{inputs.parameters.loki-username}} --password={{inputs.parameters.loki-password}} \
+               --from=$start --limit={{inputs.parameters.limit}} \
                '{namespace="{{inputs.parameters.ns}}", instance="'$pod'"}' > $pod.log
             done
 

--- a/argo/template/ledger.yaml
+++ b/argo/template/ledger.yaml
@@ -18,6 +18,12 @@ spec:
             default: ""
           - name: run_time
             default: "60m"
+          - name: loki-addr
+            default: http://gateway.loki.svc
+          - name: loki-username
+            default: loki
+          - name: loki-password
+            default: admin
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'
@@ -33,9 +39,6 @@ spec:
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
             -run-time={{inputs.parameters.run_time}} \
-            -loki-addr=http://gateway.loki.svc \
-            -loki-username=loki \
-            -loki-password=admin
-      retryStrategy:
-        limit: 0
-        retryPolicy: Always
+            -loki-addr={{inputs.parameters.loki-addr}} \
+            -loki-username={{inputs.parameters.loki-username}} \
+            -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/region-available.yaml
+++ b/argo/template/region-available.yaml
@@ -18,6 +18,12 @@ spec:
             default: ""
           - name: run_time
             default: "4h"
+          - name: loki-addr
+            default: http://gateway.loki.svc
+          - name: loki-username
+            default: loki
+          - name: loki-password
+            default: admin
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'
@@ -33,9 +39,6 @@ spec:
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
             -run-time={{inputs.parameters.run_time}} \
-            -loki-addr=http://gateway.loki.svc \
-            -loki-username=loki \
-            -loki-password=admin
-      retryStrategy:
-        limit: 0
-        retryPolicy: Always
+            -loki-addr={{inputs.parameters.loki-addr}} \
+            -loki-username={{inputs.parameters.loki-username}} \
+            -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/sqllogic.yaml
+++ b/argo/template/sqllogic.yaml
@@ -14,6 +14,12 @@ spec:
             default: nightly
           - name: storage_class
             default: standard
+          - name: loki-addr
+            default: http://gateway.loki.svc
+          - name: loki-username
+            default: loki
+          - name: loki-password
+            default: admin
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'
@@ -30,9 +36,6 @@ spec:
             -run-time=8h \
             -p=https://codeload.github.com/mahjonp/sqllogictest/zip/tipocket \
             -d=sqllogictest-tipocket \
-            -loki-addr=http://gateway.loki.svc \
-            -loki-username=loki \
-            -loki-password=admin
-      retryStrategy:
-        limit: 0
-        retryPolicy: Always
+            -loki-addr={{inputs.parameters.loki-addr}} \
+            -loki-username={{inputs.parameters.loki-username}} \
+            -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/sqllogic.yaml
+++ b/argo/template/sqllogic.yaml
@@ -14,6 +14,8 @@ spec:
             default: nightly
           - name: storage_class
             default: standard
+          - name: run_time
+            default: "8h"
           - name: loki-addr
             default: http://gateway.loki.svc
           - name: loki-username
@@ -33,7 +35,7 @@ spec:
             -storage-class={{inputs.parameters.storage_class}} \
             -image-version={{inputs.parameters.image_version}} \
             -purge={{inputs.parameters.purge}} \
-            -run-time=8h \
+            -run-time={{inputs.parameters.run_time}} \
             -p=https://codeload.github.com/mahjonp/sqllogictest/zip/tipocket \
             -d=sqllogictest-tipocket \
             -loki-addr={{inputs.parameters.loki-addr}} \

--- a/argo/template/tpcc.yaml
+++ b/argo/template/tpcc.yaml
@@ -22,6 +22,12 @@ spec:
             default: "10"
           - name: nemesis
             default: ""
+          - name: loki-addr
+            default: http://gateway.loki.svc
+          - name: loki-username
+            default: loki
+          - name: loki-password
+            default: admin
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'
@@ -39,9 +45,6 @@ spec:
             -nemesis={{inputs.parameters.nemesis}} \
             -round={{inputs.parameters.round}} \
             -request-count={{inputs.parameters.request_count}} \
-            -loki-addr=http://gateway.loki.svc \
-            -loki-username=loki \
-            -loki-password=admin
-      retryStrategy:
-        limit: 0
-        retryPolicy: Always
+            -loki-addr={{inputs.parameters.loki-addr}} \
+            -loki-username={{inputs.parameters.loki-username}} \
+            -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/txn-rand-pessimistic.yaml
+++ b/argo/template/txn-rand-pessimistic.yaml
@@ -18,6 +18,12 @@ spec:
             default: ""
           - name: run_time
             default: "4h"
+          - name: loki-addr
+            default: http://gateway.loki.svc
+          - name: loki-username
+            default: loki
+          - name: loki-password
+            default: admin
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'
@@ -33,9 +39,6 @@ spec:
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
             -run-time={{inputs.parameters.run_time}} \
-            -loki-addr=http://gateway.loki.svc \
-            -loki-username=loki \
-            -loki-password=admin
-      retryStrategy:
-        limit: 0
-        retryPolicy: Always
+            -loki-addr={{inputs.parameters.loki-addr}} \
+            -loki-username={{inputs.parameters.loki-username}} \
+            -loki-password={{inputs.parameters.loki-password}}

--- a/argo/workflow/abtest-chunk-rpc.yaml
+++ b/argo/workflow/abtest-chunk-rpc.yaml
@@ -18,6 +18,8 @@ spec:
         value: release-4.0-nightly
       - name: nemesis
         value: ""
+      - name: client
+        value: "2"
       - name: tidb_config
         value: "/config/tidb/enable-chunk-rpc.toml"
       - name: tikv_config
@@ -61,6 +63,8 @@ spec:
                   value: "{{workflow.parameters.abtest_version}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
+                - name: client
+                  value: "{{workflow.parameters.client}}"
                 - name: tidb_config
                   value: "{{workflow.parameters.tidb_config}}"
                 - name: tikv_config

--- a/argo/workflow/abtest-chunk-rpc.yaml
+++ b/argo/workflow/abtest-chunk-rpc.yaml
@@ -4,6 +4,32 @@ metadata:
 spec:
   entrypoint: call-tipocket-abtest
   onExit: call-export-logs
+  arguments:
+    parameters:
+      - name: ns
+        value: tipocket-ab-enable-thunk
+      - name: purge
+        value: "true"
+      - name: image_version
+        value: release-4.0-nightly
+      - name: storage_class
+        value: pd-ssd
+      - name: abtest_version
+        value: release-4.0-nightly
+      - name: nemesis
+        value: ""
+      - name: tidb_config
+        value: "/config/tidb/enable-chunk-rpc.toml"
+      - name: tikv_config
+        value: ""
+      - name: pd_config
+        value: ""
+      - name: abtest_tidb_config
+        value: "/config/tidb/enable-chunk-rpc-false.toml"
+      - name: abtest_tikv_config
+        value: ""
+      - name: abtest_pd_config
+        value: ""
   templates:
     - name: call-export-logs
       steps:
@@ -14,7 +40,7 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-abtest
+                  value: "{{workflow.parameters.ns}}"
     - name: call-tipocket-abtest
       steps:
         - - name: call-tipocket-abtest
@@ -24,27 +50,26 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-ab-enable-thunk
+                  value: "{{workflow.parameters.ns}}"
                 - name: purge
-                  value: "true"
+                  value: "{{workflow.parameters.purge}}"
                 - name: image_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.image_version}}"
                 - name: storage_class
-                  value: pd-ssd
+                  value: "{{workflow.parameters.storage_class}}"
                 - name: abtest_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.abtest_version}}"
                 - name: nemesis
-                  value: ""
+                  value: "{{workflow.parameters.nemesis}}"
                 - name: tidb_config
-                  value: "/config/tidb/enable-chunk-rpc.toml"
+                  value: "{{workflow.parameters.tidb_config}}"
                 - name: tikv_config
-                  value: ""
+                  value: "{{workflow.parameters.tikv_config}}"
                 - name: pd_config
-                  value: ""
+                  value: "{{workflow.parameters.pd_config}}"
                 - name: abtest_tidb_config
-                  value: "/config/tidb/enable-chunk-rpc-false.toml"
+                  value: "{{workflow.parameters.abtest_tidb_config}}"
                 - name: abtest_tikv_config
-                  value: ""
+                  value: "{{workflow.parameters.abtest_tikv_config}}"
                 - name: abtest_pd_config
-                  value: ""
-
+                  value: "{{workflow.parameters.abtest_pd_config}}"

--- a/argo/workflow/abtest-plan-cache.yaml
+++ b/argo/workflow/abtest-plan-cache.yaml
@@ -4,6 +4,32 @@ metadata:
 spec:
   entrypoint: call-tipocket-abtest
   onExit: call-export-logs
+  arguments:
+    parameters:
+      - name: ns
+        value: tipocket-ab-plan-cache
+      - name: purge
+        value: "true"
+      - name: image_version
+        value: release-4.0-nightly
+      - name: storage_class
+        value: pd-ssd
+      - name: abtest_version
+        value: release-4.0-nightly
+      - name: nemesis
+        value: ""
+      - name: tidb_config
+        value: "/config/tidb/prepared-plan-cache.toml"
+      - name: tikv_config
+        value: ""
+      - name: pd_config
+        value: ""
+      - name: abtest_tidb_config
+        value: "/config/tidb/prepared-plan-cache-false.toml"
+      - name: abtest_tikv_config
+        value: ""
+      - name: abtest_pd_config
+        value: ""
   templates:
     - name: call-export-logs
       steps:
@@ -14,7 +40,7 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-abtest
+                  value: "{{workflow.parameters.ns}}"
     - name: call-tipocket-abtest
       steps:
         - - name: call-tipocket-abtest
@@ -24,27 +50,26 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-ab-plan-cache
+                  value: "{{workflow.parameters.ns}}"
                 - name: purge
-                  value: "true"
+                  value: "{{workflow.parameters.purge}}"
                 - name: image_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.image_version}}"
                 - name: storage_class
-                  value: pd-ssd
+                  value: "{{workflow.parameters.storage_class}}"
                 - name: abtest_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.abtest_version}}"
                 - name: nemesis
-                  value: ""
+                  value: "{{workflow.parameters.nemesis}}"
                 - name: tidb_config
-                  value: "/config/tidb/prepared-plan-cache.toml"
+                  value: "{{workflow.parameters.tidb_config}}"
                 - name: tikv_config
-                  value: ""
+                  value: "{{workflow.parameters.tikv_config}}"
                 - name: pd_config
-                  value: ""
+                  value: "{{workflow.parameters.pd_config}}"
                 - name: abtest_tidb_config
-                  value: "/config/tidb/prepared-plan-cache-false.toml"
+                  value: "{{workflow.parameters.abtest_tidb_config}}"
                 - name: abtest_tikv_config
-                  value: ""
+                  value: "{{workflow.parameters.abtest_tikv_config}}"
                 - name: abtest_pd_config
-                  value: ""
-
+                  value: "{{workflow.parameters.abtest_pd_config}}"

--- a/argo/workflow/abtest-plan-cache.yaml
+++ b/argo/workflow/abtest-plan-cache.yaml
@@ -18,6 +18,8 @@ spec:
         value: release-4.0-nightly
       - name: nemesis
         value: ""
+      - name: client
+        value: "2"
       - name: tidb_config
         value: "/config/tidb/prepared-plan-cache.toml"
       - name: tikv_config
@@ -61,6 +63,8 @@ spec:
                   value: "{{workflow.parameters.abtest_version}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
+                - name: client
+                  value: "{{workflow.parameters.client}}"
                 - name: tidb_config
                   value: "{{workflow.parameters.tidb_config}}"
                 - name: tikv_config

--- a/argo/workflow/abtest-tmp-storage.yaml
+++ b/argo/workflow/abtest-tmp-storage.yaml
@@ -4,6 +4,32 @@ metadata:
 spec:
   entrypoint: call-tipocket-abtest
   onExit: call-export-logs
+  arguments:
+    parameters:
+      - name: ns
+        value: tipocket-ab-tmp-storage
+      - name: purge
+        value: "true"
+      - name: image_version
+        value: release-4.0-nightly
+      - name: storage_class
+        value: pd-ssd
+      - name: abtest_version
+        value: release-4.0-nightly
+      - name: nemesis
+        value: ""
+      - name: tidb_config
+        value: "/config/tidb/oom-use-tmp-storage.toml"
+      - name: tikv_config
+        value: ""
+      - name: pd_config
+        value: ""
+      - name: abtest_tidb_config
+        value: "/config/tidb/oom-use-tmp-storage-false.toml"
+      - name: abtest_tikv_config
+        value: ""
+      - name: abtest_pd_config
+        value: ""
   templates:
     - name: call-export-logs
       steps:
@@ -14,7 +40,7 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-ab-tmp-storage
+                  value: "{{workflow.parameters.ns}}"
     - name: call-tipocket-abtest
       steps:
         - - name: call-tipocket-abtest
@@ -24,27 +50,26 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-ab-tmp-storage
+                  value: "{{workflow.parameters.ns}}"
                 - name: purge
-                  value: "true"
+                  value: "{{workflow.parameters.purge}}"
                 - name: image_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.image_version}}"
                 - name: storage_class
-                  value: pd-ssd
+                  value: "{{workflow.parameters.storage_class}}"
                 - name: abtest_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.abtest_version}}"
                 - name: nemesis
-                  value: ""
+                  value: "{{workflow.parameters.nemesis}}"
                 - name: tidb_config
-                  value: "/config/tidb/oom-use-tmp-storage.toml"
+                  value: "{{workflow.parameters.tidb_config}}"
                 - name: tikv_config
-                  value: ""
+                  value: "{{workflow.parameters.tikv_config}}"
                 - name: pd_config
-                  value: ""
+                  value: "{{workflow.parameters.pd_config}}"
                 - name: abtest_tidb_config
-                  value: "/config/tidb/oom-use-tmp-storage-false.toml"
+                  value: "{{workflow.parameters.abtest_tidb_config}}"
                 - name: abtest_tikv_config
-                  value: ""
+                  value: "{{workflow.parameters.abtest_tikv_config}}"
                 - name: abtest_pd_config
-                  value: ""
-
+                  value: "{{workflow.parameters.abtest_pd_config}}"

--- a/argo/workflow/abtest-tmp-storage.yaml
+++ b/argo/workflow/abtest-tmp-storage.yaml
@@ -18,6 +18,8 @@ spec:
         value: release-4.0-nightly
       - name: nemesis
         value: ""
+      - name: client
+        value: "2"
       - name: tidb_config
         value: "/config/tidb/oom-use-tmp-storage.toml"
       - name: tikv_config
@@ -61,6 +63,8 @@ spec:
                   value: "{{workflow.parameters.abtest_version}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
+                - name: client
+                  value: "{{workflow.parameters.client}}"
                 - name: tidb_config
                   value: "{{workflow.parameters.tidb_config}}"
                 - name: tikv_config

--- a/argo/workflow/abtest.yaml
+++ b/argo/workflow/abtest.yaml
@@ -18,6 +18,8 @@ spec:
         value: latest
       - name: nemesis
         value: ""
+      - name: client
+        value: "2"
       - name: tidb_config
         value: ""
       - name: tikv_config
@@ -61,6 +63,8 @@ spec:
                   value: "{{workflow.parameters.abtest_version}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
+                - name: client
+                  value: "{{workflow.parameters.client}}"
                 - name: tidb_config
                   value: "{{workflow.parameters.tidb_config}}"
                 - name: tikv_config

--- a/argo/workflow/abtest.yaml
+++ b/argo/workflow/abtest.yaml
@@ -4,6 +4,32 @@ metadata:
 spec:
   entrypoint: call-tipocket-abtest
   onExit: call-export-logs
+  arguments:
+    parameters:
+      - name: ns
+        value: tipocket-abtest
+      - name: purge
+        value: "true"
+      - name: image_version
+        value: release-4.0-nightly
+      - name: storage_class
+        value: pd-ssd
+      - name: abtest_version
+        value: latest
+      - name: nemesis
+        value: ""
+      - name: tidb_config
+        value: ""
+      - name: tikv_config
+        value: ""
+      - name: pd_config
+        value: ""
+      - name: abtest_tidb_config
+        value: ""
+      - name: abtest_tikv_config
+        value: ""
+      - name: abtest_pd_config
+        value: ""
   templates:
     - name: call-export-logs
       steps:
@@ -14,7 +40,7 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-abtest
+                  value: "{{workflow.parameters.ns}}"
     - name: call-tipocket-abtest
       steps:
         - - name: call-tipocket-abtest
@@ -24,27 +50,26 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-abtest
+                  value: "{{workflow.parameters.ns}}"
                 - name: purge
-                  value: "true"
+                  value: "{{workflow.parameters.purge}}"
                 - name: image_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.image_version}}"
                 - name: storage_class
-                  value: pd-ssd
+                  value: "{{workflow.parameters.storage_class}}"
                 - name: abtest_version
-                  value: latest
+                  value: "{{workflow.parameters.abtest_version}}"
                 - name: nemesis
-                  value: ""
+                  value: "{{workflow.parameters.nemesis}}"
                 - name: tidb_config
-                  value: ""
+                  value: "{{workflow.parameters.tidb_config}}"
                 - name: tikv_config
-                  value: ""
+                  value: "{{workflow.parameters.tikv_config}}"
                 - name: pd_config
-                  value: ""
+                  value: "{{workflow.parameters.pd_config}}"
                 - name: abtest_tidb_config
-                  value: ""
+                  value: "{{workflow.parameters.abtest_tidb_config}}"
                 - name: abtest_tikv_config
-                  value: ""
+                  value: "{{workflow.parameters.abtest_tikv_config}}"
                 - name: abtest_pd_config
-                  value: ""
-
+                  value: "{{workflow.parameters.abtest_pd_config}}"

--- a/argo/workflow/bank-iochaos.yaml
+++ b/argo/workflow/bank-iochaos.yaml
@@ -3,7 +3,36 @@ metadata:
   namespace: argo
 spec:
   entrypoint: call-tipocket-bank-iochaos
+  onExit: call-export-logs
+  inputs:
+    parameters:
+      - name: ns
+        value: tipocket-bank-iochaos
+      - name: purge
+        value: "false"
+      - name: image_version
+        value: nightly
+      - name: storage_class
+        value: local-scsi
+      - name: nemesis
+        value: "delay_tikv"
+      - name: client
+        value: "5"
+      - name: request_count
+        value: "10000"
+      - name: round
+        value: "100"
   templates:
+    - name: call-export-logs
+      steps:
+        - - name: call-export-logs
+            templateRef:
+              name: export-logs
+              template: export-logs
+            arguments:
+              parameters:
+                - name: ns
+                  value: "{{workflow.parameters.ns}}"
     - name: call-tipocket-bank-iochaos
       steps:
         - - name: call-tipocket-bank-iochaos
@@ -12,7 +41,19 @@ spec:
               template: tipocket-bank-iochaos
             arguments:
               parameters:
+                - name: ns
+                  value: "{{workflow.parameters.ns}}"
+                - name: purge
+                  value: "{{workflow.parameters.purge}}"
                 - name: image_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.image_version}}"
                 - name: storage_class
-                  value: local-scsi
+                  value: "{{workflow.parameters.storage_class}}"
+                - name: nemesis
+                  value: "{{workflow.parameters.nemesis}}"
+                - name: client
+                  value: "{{workflow.parameters.client}}"
+                - name: request_count
+                  value: "{{workflow.parameters.request_count}}"
+                - name: round
+                  value: "{{workflow.parameters.round}}"

--- a/argo/workflow/bank.yaml
+++ b/argo/workflow/bank.yaml
@@ -4,6 +4,24 @@ metadata:
 spec:
   entrypoint: call-tipocket-bank
   onExit: call-export-logs
+  arguments:
+    parameters:
+      - name: ns
+        value: tipocket-bank
+      - name: purge
+        value: "true"
+      - name: image_version
+        value: release-4.0-nightly
+      - name: storage_class
+        value: pd-ssd
+      - name: nemesis
+        value: random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler
+      - name: client
+        value: "5"
+      - name: request_count
+        value: "20000"
+      - name: round
+        value: "100"
   templates:
     - name: call-export-logs
       steps:
@@ -14,7 +32,7 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-bank
+                  value: "{{workflow.parameters.ns}}"
     - name: call-tipocket-bank
       steps:
         - - name: call-tipocket-bank
@@ -24,19 +42,19 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-bank
+                  value: "{{workflow.parameters.ns}}"
                 - name: purge
-                  value: "true"
+                  value: "{{workflow.parameters.purge}}"
                 - name: image_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.image_version}}"
                 - name: storage_class
-                  value: pd-ssd
+                  value: "{{workflow.parameters.storage_class}}"
                 - name: nemesis
-                  value: random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler
+                  value: "{{workflow.parameters.nemesis}}"
                 - name: client
-                  value: "5"
+                  value: "{{workflow.parameters.client}}"
                 - name: request_count
-                  value: "20000"
+                  value: "{{workflow.parameters.request_count}}"
                 - name: round
-                  value: "100"
+                  value: "{{workflow.parameters.round}}"
 

--- a/argo/workflow/binlog.yaml
+++ b/argo/workflow/binlog.yaml
@@ -4,6 +4,22 @@ metadata:
 spec:
   entrypoint: call-tipocket-binlog
   onExit: call-export-logs
+  arguments:
+    parameters:
+      - name: ns
+        value: tipocket-binlog
+      - name: purge
+        value: "false"
+      - name: image_version
+        value: release-4.0-nightly
+      - name: storage_class
+        value: pd-ssd
+      - name: nemesis
+        value: ""
+      - name: run_time
+        value: "60m"
+      - name: relay_log
+        value: "true"
   templates:
     - name: call-export-logs
       steps:
@@ -14,7 +30,7 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-binlog
+                  value: "{{workflow.parameters.ns}}"
     - name: call-tipocket-binlog
       steps:
         - - name: call-tipocket-binlog
@@ -24,16 +40,16 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-binlog
+                  value: "{{workflow.parameters.ns}}"
                 - name: purge
-                  value: "false"
+                  value: "{{workflow.parameters.purge}}"
                 - name: image_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.image_version}}"
                 - name: storage_class
-                  value: pd-ssd
+                  value: "{{workflow.parameters.storage_class}}"
                 - name: nemesis
-                  value: ""
+                  value: "{{workflow.parameters.nemesis}}"
                 - name: run_time
-                  value: "60m"
+                  value: "{{workflow.parameters.run_time}}"
                 - name: relay_log
-                  value: "true"
+                  value: "{{workflow.parameters.relay_log}}"

--- a/argo/workflow/block-writer.yaml
+++ b/argo/workflow/block-writer.yaml
@@ -4,6 +4,20 @@ metadata:
 spec:
   entrypoint: call-tipocket-block-writer
   onExit: call-export-logs
+  arguments:
+    parameters:
+      - name: ns
+        value: tipocket-block-writer
+      - name: purge
+        value: "true"
+      - name: image_version
+        value: release-4.0-nightly
+      - name: storage_class
+        value: pd-ssd
+      - name: nemesis
+        value: ""
+      - name: run_time
+        value: "60m"
   templates:
     - name: call-export-logs
       steps:
@@ -14,7 +28,7 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-block-writer
+                  value: "{{workflow.parameters.ns}}"
     - name: call-tipocket-block-writer
       steps:
         - - name: call-tipocket-block-writer
@@ -24,14 +38,14 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-block-writer
+                  value: "{{workflow.parameters.ns}}"
                 - name: purge
-                  value: "true"
+                  value: "{{workflow.parameters.purge}}"
                 - name: image_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.image_version}}"
                 - name: storage_class
-                  value: pd-ssd
+                  value: "{{workflow.parameters.storage_class}}"
                 - name: nemesis
-                  value: ""
+                  value: "{{workflow.parameters.nemesis}}"
                 - name: run_time
-                  value: "60m"
+                  value: "{{workflow.parameters.run_time}}"

--- a/argo/workflow/ledger.yaml
+++ b/argo/workflow/ledger.yaml
@@ -4,6 +4,20 @@ metadata:
 spec:
   entrypoint: call-tipocket-ledger
   onExit: call-export-logs
+  arguments:
+    parameters:
+      - name: ns
+        value: tipocket-ledger
+      - name: purge
+        value: "true"
+      - name: image_version
+        value: release-4.0-nightly
+      - name: storage_class
+        value: pd-ssd
+      - name: nemesis
+        value: ""
+      - name: run_time
+        value: "60m"
   templates:
     - name: call-export-logs
       steps:
@@ -14,7 +28,7 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-ledger
+                  value: "{{workflow.parameters.ns}}"
     - name: call-tipocket-ledger
       steps:
         - - name: call-tipocket-ledger
@@ -24,14 +38,14 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-ledger
+                  value: "{{workflow.parameters.ns}}"
                 - name: purge
-                  value: "true"
+                  value: "{{workflow.parameters.purge}}"
                 - name: image_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.image_version}}"
                 - name: storage_class
-                  value: pd-ssd
+                  value: "{{workflow.parameters.storage_class}}"
                 - name: nemesis
-                  value: ""
+                  value: "{{workflow.parameters.nemesis}}"
                 - name: run_time
-                  value: "60m"
+                  value: "{{workflow.parameters.run_time}}"

--- a/argo/workflow/region-available.yaml
+++ b/argo/workflow/region-available.yaml
@@ -4,6 +4,20 @@ metadata:
 spec:
   entrypoint: call-tipocket-region-available
   onExit: call-export-logs
+  arguments:
+    parameters:
+      - name: ns
+        value: tipocket-region-available
+      - name: purge
+        value: "true"
+      - name: image_version
+        value: release-4.0-nightly
+      - name: storage_class
+        value: pd-ssd
+      - name: nemesis
+        value: ""
+      - name: run_time
+        value: "4h"
   templates:
     - name: call-export-logs
       steps:
@@ -14,7 +28,7 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-region-available
+                  value: "{{workflow.parameters.ns}}"
     - name: call-tipocket-region-available
       steps:
         - - name: call-tipocket-region-available
@@ -24,14 +38,14 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-region-available
+                  value: "{{workflow.parameters.ns}}"
                 - name: purge
-                  value: "true"
+                  value: "{{workflow.parameters.purge}}"
                 - name: image_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.image_version}}"
                 - name: storage_class
-                  value: pd-ssd
+                  value: "{{workflow.parameters.storage_class}}"
                 - name: nemesis
-                  value: ""
+                  value: "{{workflow.parameters.nemesis}}"
                 - name: run_time
-                  value: "4h"
+                  value: "{{workflow.parameters.run_time}}"

--- a/argo/workflow/sqllogic.yaml
+++ b/argo/workflow/sqllogic.yaml
@@ -4,6 +4,16 @@ metadata:
 spec:
   entrypoint: call-tipocket-sqllogic
   onExit: call-export-logs
+  arguments:
+    parameters:
+      - name: ns
+        value: tipocket-sqllogic
+      - name: purge
+        value: "true"
+      - name: image_version
+        value: release-4.0-nightly
+      - name: storage_class
+        value: pd-ssd
   templates:
     - name: call-export-logs
       steps:
@@ -14,7 +24,7 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-sqllogic
+                  value: "{{workflow.parameters.ns}}"
     - name: call-tipocket-sqllogic
       steps:
         - - name: call-tipocket-sqllogic
@@ -24,10 +34,10 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-sqllogic
+                  value: "{{workflow.parameters.ns}}"
                 - name: purge
-                  value: "true"
+                  value: "{{workflow.parameters.purge}}"
                 - name: image_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.image_version}}"
                 - name: storage_class
-                  value: pd-ssd
+                  value: "{{workflow.parameters.storage_class}}"

--- a/argo/workflow/sqllogic.yaml
+++ b/argo/workflow/sqllogic.yaml
@@ -14,6 +14,8 @@ spec:
         value: release-4.0-nightly
       - name: storage_class
         value: pd-ssd
+      - name: run_time
+        value: "8h"
   templates:
     - name: call-export-logs
       steps:
@@ -41,3 +43,5 @@ spec:
                   value: "{{workflow.parameters.image_version}}"
                 - name: storage_class
                   value: "{{workflow.parameters.storage_class}}"
+                - name: run_time
+                  value: "{{workflow.parameters.run_time}}"

--- a/argo/workflow/tpcc.yaml
+++ b/argo/workflow/tpcc.yaml
@@ -4,6 +4,24 @@ metadata:
 spec:
   entrypoint: call-tipocket-tpcc
   onExit: call-export-logs
+  arguments:
+    parameters:
+    - name: ns
+      value: tipocket-tpcc
+    - name: purge
+      value: "true"
+    - name: image_version
+      value: release-4.0-nightly
+    - name: storage_class
+      value: pd-ssd
+    - name: nemesis
+      value: random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler
+    - name: client
+      value: "100"
+    - name: request_count
+      value: "1000000"
+    - name: round
+      value: "10"
   templates:
     - name: call-export-logs
       steps:
@@ -14,7 +32,7 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-tpcc
+                  value: "{{workflow.parameters.ns}}"
     - name: call-tipocket-tpcc
       steps:
         - - name: call-tipocket-tpcc
@@ -24,18 +42,18 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-tpcc
+                  value: "{{workflow.parameters.ns}}"
                 - name: purge
-                  value: "true"
+                  value: "{{workflow.parameters.purge}}"
                 - name: image_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.image_version}}"
                 - name: storage_class
-                  value: pd-ssd
+                  value: "{{workflow.parameters.storage_class}}"
                 - name: nemesis
-                  value: random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler
+                  value: "{{workflow.parameters.nemesis}}"
                 - name: client
-                  value: "100"
+                  value: "{{workflow.parameters.client}}"
                 - name: request_count
-                  value: "1000000"
+                  value: "{{workflow.parameters.request_count}}"
                 - name: round
-                  value: "10"
+                  value: "{{workflow.parameters.round}}"

--- a/argo/workflow/txn-rand-pessimistic.yaml
+++ b/argo/workflow/txn-rand-pessimistic.yaml
@@ -4,6 +4,20 @@ metadata:
 spec:
   entrypoint: call-tipocket-txn-rand-pessimistic
   onExit: call-export-logs
+  arguments:
+    parameters:
+      - name: ns
+        value: tipocket-txn-rand-pessimistic
+      - name: purge
+        value: "true"
+      - name: image_version
+        value: release-4.0-nightly
+      - name: storage_class
+        value: pd-ssd
+      - name: nemesis
+        value: random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler
+      - name: run_time
+        value: "4h"
   templates:
     - name: call-export-logs
       steps:
@@ -24,14 +38,14 @@ spec:
             arguments:
               parameters:
                 - name: ns
-                  value: tipocket-txn-rand-pessimistic
+                  value: "{{workflow.parameters.ns}}"
                 - name: purge
-                  value: "true"
+                  value: "{{workflow.parameters.purge}}"
                 - name: image_version
-                  value: release-4.0-nightly
+                  value: "{{workflow.parameters.image_version}}"
                 - name: storage_class
-                  value: pd-ssd
+                  value: "{{workflow.parameters.storage_class}}"
                 - name: nemesis
-                  value: random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler
+                  value: "{{workflow.parameters.nemesis}}"
                 - name: run_time
-                  value: "4h"
+                  value: "{{workflow.parameters.run_time}}"


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

There is a bug in current workflow manifest. Template `call-export-logs` and template `call-tipocket-xxx` both has a `ns` parameter, so when trying to submit workflow via argo cli with parameter overwritten such as `-p ns=xxx`, the namespace won't change (not sure why). The solution for this is to make the input parameter global, so that each template can render that value as its input. 

This PR also does:
1. remove `retryStrategy`
2. make loki related parameters configurable

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
