### PR TITLE
pocket: fix pocket check while executing SQL

### DIFF
--- a/pkg/pocket/core/check.go
+++ b/pkg/pocket/core/check.go
@@ -120,6 +120,7 @@ func (c *Core) abTestCompareData(delay bool) (bool, error) {
 
 	// commit or rollback all transactions
 	log.Info("before lock")
+	c.execMutex.Lock()
 	c.Lock()
 	log.Info("after lock")
 	// no async here to ensure all transactions are committed or rollbacked in order
@@ -144,6 +145,7 @@ func (c *Core) abTestCompareData(delay bool) (bool, error) {
 	defer func() {
 		log.Info("free lock")
 		c.Unlock()
+		defer c.execMutex.Unlock()
 	}()
 
 	// delay will hold on this snapshot and check it later
@@ -173,6 +175,7 @@ func (c *Core) binlogTestCompareData(delay bool) (bool, error) {
 
 	// commit or rollback all transactions
 	// lock here before get snapshot
+	c.execMutex.Lock()
 	c.Lock()
 	// no async here to ensure all transactions are committed or rollbacked in order
 	// use resolveDeadLock func to avoid deadlock
@@ -208,6 +211,7 @@ func (c *Core) binlogTestCompareData(delay bool) (bool, error) {
 	}
 	if err := compareExecutor.ABTestTxnBegin(); err != nil {
 		c.Unlock()
+		c.execMutex.Lock()
 		return false, errors.Trace(err)
 	}
 	log.Info("compare wait for chan finish")

--- a/pkg/pocket/core/core.go
+++ b/pkg/pocket/core/core.go
@@ -39,8 +39,9 @@ type Core struct {
 	lockWatchCh chan int
 	order       *types.Order
 	// lock
-	mutex  sync.Mutex
-	ifLock bool
+	mutex     sync.Mutex
+	execMutex sync.Mutex
+	ifLock    bool
 }
 
 // New creates a Core struct

--- a/pkg/pocket/core/execute.go
+++ b/pkg/pocket/core/execute.go
@@ -23,6 +23,8 @@ import (
 )
 
 func (c *Core) execute(e *executor.Executor, sql *types.SQL) {
+	c.execMutex.Lock()
+	defer c.execMutex.Unlock()
 	// wait for execute finish
 	// may not ignore the errors here
 	if c.cfg.Options.Serialize && sql.ExecTime != 0 {


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Currently there is a rarely happened bug, when the generator is locked, the SQL already generated may be executed. To fix this problem, this PR add a lock for executor, not the best way, but it works.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
