### PR TITLE
Add primary key when to create wait table

### DIFF
--- a/pkg/pocket/core/check.go
+++ b/pkg/pocket/core/check.go
@@ -275,5 +275,5 @@ func makeCompareSQLs(schema [][5]string) []string {
 func generateWaitTable() (string, string) {
 	sec := time.Now().Unix()
 	table := fmt.Sprintf("t%d", sec)
-	return table, fmt.Sprintf("CREATE TABLE %s(id int)", table)
+	return table, fmt.Sprintf("CREATE TABLE %s(id int PRIMARY KEY)", table)
 }


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

CDC requires tables to have pk or unique indexes

### What is changed and how does it work?

Add primary key when to create wait table

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
