### PR TITLE
Remove version field in tidbcluster

### DIFF
--- a/pkg/test-infra/tidb/recommend.go
+++ b/pkg/test-infra/tidb/recommend.go
@@ -94,7 +94,6 @@ func RecommendedTiDBCluster(ns, name, version string) *Recommendation {
 				},
 			},
 			Spec: v1alpha1.TidbClusterSpec{
-				Version:         version,
 				PVReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
 				EnablePVReclaim: &enablePVReclaim,
 				ImagePullPolicy: corev1.PullAlways,
@@ -103,7 +102,6 @@ func RecommendedTiDBCluster(ns, name, version string) *Recommendation {
 					ResourceRequirements: fixture.WithStorage(fixture.Medium, "10Gi"),
 					StorageClassName:     &fixture.Context.LocalVolumeStorageClass,
 					ComponentSpec: v1alpha1.ComponentSpec{
-						Version: &version,
 						Image:   buildImage("pd", version),
 					},
 				},
@@ -114,7 +112,6 @@ func RecommendedTiDBCluster(ns, name, version string) *Recommendation {
 					// disable auto fail over
 					MaxFailoverCount: pointer.Int32Ptr(int32(0)),
 					ComponentSpec: v1alpha1.ComponentSpec{
-						Version: &version,
 						Image:   buildImage("tikv", version),
 					},
 				},
@@ -130,7 +127,6 @@ func RecommendedTiDBCluster(ns, name, version string) *Recommendation {
 					// disable auto fail over
 					MaxFailoverCount: pointer.Int32Ptr(int32(0)),
 					ComponentSpec: v1alpha1.ComponentSpec{
-						Version: &version,
 						Image:   buildImage("tidb", version),
 					},
 				},


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Currently we set the version field in the tidbcluster CR.  But actually this introduces a bug in tidb-operator. Tidb operator uses the `baseImage` field instead of the `image` field when version is not `""`, so when we want to use the images from `hub.pingcap.net`, it won't work. So this PR removes the `version` field in tidbcluster CR.

``` go
// This function set baseimage to not "" when version is not "".
func setPdSpecDefault(tc *v1alpha1.TidbCluster) {
	if len(tc.Spec.Version) > 0 || tc.Spec.PD.Version != nil {
		if tc.Spec.PD.BaseImage == "" {
			tc.Spec.PD.BaseImage = defaultPDImage
		}
	}
}

// This function overwrites the image.
func (tc *TidbCluster) PDImage() string {
	image := tc.Spec.PD.Image
	baseImage := tc.Spec.PD.BaseImage
	// base image takes higher priority
	if baseImage != "" {
		version := tc.Spec.PD.Version
		if version == nil {
			version = &tc.Spec.Version
		}
		image = fmt.Sprintf("%s:%s", baseImage, *version)
	}
	return image
}
```



### What is changed and how does it work?
