### PR TITLE
pocket: fix startup in binlog workload

### DIFF
--- a/argo/template/abtest.yaml
+++ b/argo/template/abtest.yaml
@@ -34,6 +34,8 @@ spec:
             default: ""
           - name: abtest_pd_config
             default: ""
+          - name: abtest_concurrency
+            default: "3"
           - name: abtest_general_log
             default: "true"
           - name: loki-addr
@@ -65,6 +67,7 @@ spec:
             -abtest.tidb-config={{inputs.parameters.abtest_tidb_config}} \
             -abtest.tikv-config={{inputs.parameters.abtest_tikv_config}} \
             -abtest.pd-config={{inputs.parameters.abtest_pd_config}} \
+            -abtest.concurrency={{inputs.parameters.abtest_concurrency}} \
             -abtest.general={{inputs.parameters.abtest_general_log}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \

--- a/argo/template/binlog.yaml
+++ b/argo/template/binlog.yaml
@@ -20,6 +20,10 @@ spec:
             default: "48h"
           - name: relay_log
             default: "true"
+          - name: abtest_general_log
+            default: "true"
+          - name: binlog_sync_timeout
+            default: "1h"
           - name: loki-addr
             default: http://gateway.loki.svc
           - name: loki-username
@@ -42,6 +46,8 @@ spec:
             -nemesis={{inputs.parameters.nemesis}} \
             -run-time={{inputs.parameters.run_time}} \
             -relay-log={{inputs.parameters.relay_log}} \
+            -abtest.general={{inputs.parameters.abtest_general_log}} \
+            -binlog.sync-timeout={{inputs.parameters.binlog_sync_timeout}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/binlog.yaml
+++ b/argo/template/binlog.yaml
@@ -22,6 +22,8 @@ spec:
             default: "true"
           - name: abtest_general_log
             default: "true"
+          - name: abtest_concurrency
+            default: "3"
           - name: binlog_sync_timeout
             default: "1h"
           - name: loki-addr
@@ -46,6 +48,7 @@ spec:
             -nemesis={{inputs.parameters.nemesis}} \
             -run-time={{inputs.parameters.run_time}} \
             -relay-log={{inputs.parameters.relay_log}} \
+            -abtest.concurrency={{inputs.parameters.abtest_concurrency}} \
             -abtest.general={{inputs.parameters.abtest_general_log}} \
             -binlog.sync-timeout={{inputs.parameters.binlog_sync_timeout}} \
             -loki-addr={{inputs.parameters.loki-addr}} \

--- a/argo/template/cdc.yaml
+++ b/argo/template/cdc.yaml
@@ -28,6 +28,8 @@ spec:
             default: "true"
           - name: binlog_sync_timeout
             default: "1h"
+          - name: abtest_concurrency
+            default: "3"
           - name: loki-addr
             default: http://gateway.loki.svc
           - name: loki-username
@@ -52,6 +54,7 @@ spec:
             -cdc.hub={{inputs.parameters.cdc_hub}} \
             -cdc.repository={{inputs.parameters.cdc_repository}} \
             -cdc.version={{inputs.parameters.cdc_version}} \
+            -abtest.concurrency={{inputs.parameters.abtest_concurrency}} \
             -abtest.general={{inputs.parameters.abtest_general_log}} \
             -binlog.sync-timeout={{inputs.parameters.binlog_sync_timeout}} \
             -loki-addr={{inputs.parameters.loki-addr}} \

--- a/argo/template/cdc.yaml
+++ b/argo/template/cdc.yaml
@@ -24,6 +24,10 @@ spec:
             default: pingcap
           - name: cdc_version
             default: nightly
+          - name: abtest_general_log
+            default: "true"
+          - name: binlog_sync_timeout
+            default: "1h"
           - name: loki-addr
             default: http://gateway.loki.svc
           - name: loki-username
@@ -48,6 +52,8 @@ spec:
             -cdc.hub={{inputs.parameters.cdc_hub}} \
             -cdc.repository={{inputs.parameters.cdc_repository}} \
             -cdc.version={{inputs.parameters.cdc_version}} \
+            -abtest.general={{inputs.parameters.abtest_general_log}} \
+            -binlog.sync-timeout={{inputs.parameters.binlog_sync_timeout}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/sc_bank.yaml
+++ b/argo/template/sc_bank.yaml
@@ -52,5 +52,5 @@ spec:
             -tikv-replicas={{inputs.parameters.tikv-replicas}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
-            -loki-password={{inputs.parameters.loki-password}}
+            -loki-password={{inputs.parameters.loki-password}} \
             -tidb-replica-read={{inputs.parameters.tidb-replica-read}}

--- a/argo/template/sc_bank2.yaml
+++ b/argo/template/sc_bank2.yaml
@@ -52,5 +52,5 @@ spec:
             -tikv-replicas={{inputs.parameters.tikv-replicas}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
-            -loki-password={{inputs.parameters.loki-password}}
+            -loki-password={{inputs.parameters.loki-password}} \
             -tidb-replica-read={{inputs.parameters.tidb-replica-read}}

--- a/argo/workflow/abtest-chunk-rpc.yaml
+++ b/argo/workflow/abtest-chunk-rpc.yaml
@@ -32,6 +32,8 @@ spec:
         value: ""
       - name: abtest_pd_config
         value: ""
+      - name: abtest_concurrency
+        value: "3"
       - name: abtest_general_log
         value: "true"
   templates:
@@ -79,5 +81,7 @@ spec:
                   value: "{{workflow.parameters.abtest_tikv_config}}"
                 - name: abtest_pd_config
                   value: "{{workflow.parameters.abtest_pd_config}}"
+                - name: abtest_concurrency
+                  value: "{{workflow.parameters.abtest_concurrency}}"
                 - name: abtest_general_log
                   value: "{{workflow.parameters.abtest_general_log}}"

--- a/argo/workflow/abtest-plan-cache.yaml
+++ b/argo/workflow/abtest-plan-cache.yaml
@@ -32,6 +32,8 @@ spec:
         value: ""
       - name: abtest_pd_config
         value: ""
+      - name: abtest_concurrency
+        value: "3"
       - name: abtest_general_log
         value: "true"
   templates:
@@ -79,5 +81,7 @@ spec:
                   value: "{{workflow.parameters.abtest_tikv_config}}"
                 - name: abtest_pd_config
                   value: "{{workflow.parameters.abtest_pd_config}}"
+                - name: abtest_concurrency
+                  value: "{{workflow.parameters.abtest_concurrency}}"
                 - name: abtest_general_log
                   value: "{{workflow.parameters.abtest_general_log}}"

--- a/argo/workflow/abtest-tmp-storage.yaml
+++ b/argo/workflow/abtest-tmp-storage.yaml
@@ -32,6 +32,8 @@ spec:
         value: ""
       - name: abtest_pd_config
         value: ""
+      - name: abtest_concurrency
+        value: "3"
       - name: abtest_general_log
         value: "true"
   templates:
@@ -79,5 +81,7 @@ spec:
                   value: "{{workflow.parameters.abtest_tikv_config}}"
                 - name: abtest_pd_config
                   value: "{{workflow.parameters.abtest_pd_config}}"
+                - name: abtest_concurrency
+                  value: "{{workflow.parameters.abtest_concurrency}}"
                 - name: abtest_general_log
                   value: "{{workflow.parameters.abtest_general_log}}"

--- a/argo/workflow/abtest.yaml
+++ b/argo/workflow/abtest.yaml
@@ -32,6 +32,8 @@ spec:
         value: ""
       - name: abtest_pd_config
         value: ""
+      - name: abtest_concurrency
+        value: "3"
       - name: abtest_general_log
         value: "true"
   templates:
@@ -79,5 +81,7 @@ spec:
                   value: "{{workflow.parameters.abtest_tikv_config}}"
                 - name: abtest_pd_config
                   value: "{{workflow.parameters.abtest_pd_config}}"
+                - name: abtest_concurrency
+                  value: "{{workflow.parameters.abtest_concurrency}}"
                 - name: abtest_general_log
                   value: "{{workflow.parameters.abtest_general_log}}"

--- a/argo/workflow/binlog.yaml
+++ b/argo/workflow/binlog.yaml
@@ -20,6 +20,10 @@ spec:
         value: "60m"
       - name: relay_log
         value: "true"
+      - name: abtest_general_log
+        value: "true"
+      - name: binlog_sync_timeout
+        value: "1h"
   templates:
     - name: call-export-logs
       steps:
@@ -53,3 +57,7 @@ spec:
                   value: "{{workflow.parameters.run_time}}"
                 - name: relay_log
                   value: "{{workflow.parameters.relay_log}}"
+                - name: abtest_general_log
+                  value: "{{workflow.parameters.abtest_general_log}}"
+                - name: binlog_sync_timeout
+                  value: "{{workflow.parameters.binlog_sync_timeout}}"

--- a/argo/workflow/binlog.yaml
+++ b/argo/workflow/binlog.yaml
@@ -24,6 +24,8 @@ spec:
         value: "true"
       - name: binlog_sync_timeout
         value: "1h"
+      - name: abtest_concurrency
+        value: "3"
   templates:
     - name: call-export-logs
       steps:
@@ -61,3 +63,5 @@ spec:
                   value: "{{workflow.parameters.abtest_general_log}}"
                 - name: binlog_sync_timeout
                   value: "{{workflow.parameters.binlog_sync_timeout}}"
+                - name: abtest_concurrency
+                  value: "{{workflow.parameters.abtest_concurrency}}"

--- a/argo/workflow/cdc.yaml
+++ b/argo/workflow/cdc.yaml
@@ -28,6 +28,8 @@ spec:
         value: "true"
       - name: binlog_sync_timeout
         value: "1h"
+      - name: abtest_concurrency
+        value: "3"
   templates:
     - name: call-export-logs
       steps:
@@ -69,3 +71,5 @@ spec:
                   value: "{{workflow.parameters.abtest_general_log}}"
                 - name: binlog_sync_timeout
                   value: "{{workflow.parameters.binlog_sync_timeout}}"
+                - name: abtest_concurrency
+                  value: "{{workflow.parameters.abtest_concurrency}}"

--- a/argo/workflow/cdc.yaml
+++ b/argo/workflow/cdc.yaml
@@ -24,6 +24,10 @@ spec:
         value: "pingcap"
       - name: cdc_version
         value: "nightly"
+      - name: abtest_general_log
+        value: "true"
+      - name: binlog_sync_timeout
+        value: "1h"
   templates:
     - name: call-export-logs
       steps:
@@ -61,3 +65,7 @@ spec:
                   value: "{{workflow.parameters.cdc_repository}}"
                 - name: cdc_version
                   value: "{{workflow.parameters.cdc_version}}"
+                - name: abtest_general_log
+                  value: "{{workflow.parameters.abtest_general_log}}"
+                - name: binlog_sync_timeout
+                  value: "{{workflow.parameters.binlog_sync_timeout}}"

--- a/cmd/cdc-pocket/main.go
+++ b/cmd/cdc-pocket/main.go
@@ -41,6 +41,9 @@ func main() {
 	pocketConfig := config.Init()
 	pocketConfig.Options.Serialize = false
 	pocketConfig.Options.Path = fixture.Context.CDCConfig.LogPath
+	pocketConfig.Options.Concurrency = fixture.Context.ABTestConfig.Concurrency
+	pocketConfig.Options.GeneralLog = fixture.Context.ABTestConfig.GeneralLog
+	pocketConfig.Options.SyncTimeout.Duration = fixture.Context.BinlogConfig.SyncTimeout
 	suit := util.Suit{
 		Config:      &cfg,
 		Provisioner: cluster.NewK8sProvisioner(),

--- a/cmd/pocket/main.go
+++ b/cmd/pocket/main.go
@@ -43,6 +43,7 @@ func main() {
 	pocketConfig.Options.Path = fixture.Context.ABTestConfig.LogPath
 	pocketConfig.Options.Concurrency = fixture.Context.ABTestConfig.Concurrency
 	pocketConfig.Options.GeneralLog = fixture.Context.ABTestConfig.GeneralLog
+	pocketConfig.Options.SyncTimeout.Duration = fixture.Context.BinlogConfig.SyncTimeout
 	suit := util.Suit{
 		Config:      &cfg,
 		Provisioner: cluster.NewK8sProvisioner(),

--- a/pkg/pocket/config/config.go
+++ b/pkg/pocket/config/config.go
@@ -72,7 +72,7 @@ var initConfig = Config{
 		Serialize:  true,
 		GeneralLog: false,
 		SyncTimeout: types.Duration{
-			Duration: time.Second,
+			Duration: 10 * time.Minute,
 		},
 	},
 	Generator: Generator{

--- a/pkg/pocket/config/config.go
+++ b/pkg/pocket/config/config.go
@@ -35,6 +35,7 @@ type Options struct {
 	OnlineDDL     bool           `toml:"online-ddl"`
 	Serialize     bool           `toml:"serialize"`
 	GeneralLog    bool           `toml:"general-log"`
+	SyncTimeout   types.Duration `toml:"check-duration"`
 }
 
 // Generator Config
@@ -70,6 +71,9 @@ var initConfig = Config{
 		OnlineDDL:  true,
 		Serialize:  true,
 		GeneralLog: false,
+		SyncTimeout: types.Duration{
+			Duration: time.Second,
+		},
 	},
 	Generator: Generator{
 		SQLSmith: SQLSmith{

--- a/pkg/pocket/config/config_test.go
+++ b/pkg/pocket/config/config_test.go
@@ -29,6 +29,6 @@ func TestParseConfig(t *testing.T) {
 	assert.Equal(t, config.DSN1, "root:@tcp(172.17.0.1:33306)/pocket")
 	assert.Equal(t, config.DSN2, "root:@tcp(172.17.0.1:4000)/pocket")
 	assert.Equal(t, config.Options.Duration.Duration, time.Hour)
-	assert.Equal(t, config.Options.CheckDuration.Duration, 3*time.Minute)
+	assert.Equal(t, config.Options.CheckDuration.Duration, time.Minute)
 	assert.Equal(t, config.Options.Path, "/var/log/pocket")
 }

--- a/pkg/pocket/connection/connection.go
+++ b/pkg/pocket/connection/connection.go
@@ -59,7 +59,7 @@ func New(dsn string, opt *Option) (*Connection, error) {
 // Prepare connection
 func (c *Connection) Prepare() error {
 	if c.opt.GeneralLog {
-		return c.GeneralLog(1)
+		return errors.Trace(c.GeneralLog(1))
 	}
 	return nil
 }

--- a/pkg/pocket/connection/exec.go
+++ b/pkg/pocket/connection/exec.go
@@ -145,3 +145,18 @@ func (c *Connection) GeneralLog(v int) error {
 	_, err := c.db.Exec(fmt.Sprintf("set @@tidb_general_log=\"%d\"", v))
 	return err
 }
+
+// ShowDatabases list databases
+func (c *Connection) ShowDatabases() ([]string, error) {
+	res, err := c.Select("SHOW DATABASES")
+	if err != nil {
+		return nil, err
+	}
+	var dbs []string
+	for _, db := range res {
+		if len(db) == 1 {
+			dbs = append(dbs, db[0].ValString)
+		}
+	}
+	return dbs, nil
+}

--- a/pkg/pocket/connection/exec.go
+++ b/pkg/pocket/connection/exec.go
@@ -66,27 +66,36 @@ func (c *Connection) Select(stmt string, args ...interface{}) ([][]*QueryItem, e
 
 // Update run update statement and return error
 func (c *Connection) Update(stmt string) (int64, error) {
+	var affectedRows int64
 	start := time.Now()
 	result, err := c.db.Exec(stmt)
-	affectedRows, _ := result.RowsAffected()
+	if err == nil {
+		affectedRows, _ = result.RowsAffected()
+	}
 	c.logSQL(stmt, time.Now().Sub(start), err, affectedRows)
 	return affectedRows, err
 }
 
 // Insert run insert statement and return error
 func (c *Connection) Insert(stmt string) (int64, error) {
+	var affectedRows int64
 	start := time.Now()
 	result, err := c.db.Exec(stmt)
-	affectedRows, _ := result.RowsAffected()
+	if err == nil {
+		affectedRows, _ = result.RowsAffected()
+	}
 	c.logSQL(stmt, time.Now().Sub(start), err, affectedRows)
 	return affectedRows, err
 }
 
 // Delete run delete statement and return error
 func (c *Connection) Delete(stmt string) (int64, error) {
+	var affectedRows int64
 	start := time.Now()
 	result, err := c.db.Exec(stmt)
-	affectedRows, _ := result.RowsAffected()
+	if err == nil {
+		affectedRows, _ = result.RowsAffected()
+	}
 	c.logSQL(stmt, time.Now().Sub(start), err, affectedRows)
 	return affectedRows, err
 }

--- a/pkg/pocket/core/prepare.go
+++ b/pkg/pocket/core/prepare.go
@@ -106,9 +106,9 @@ func (c *Core) clearSchema() error {
 	if !c.cfg.Options.ClearDB {
 		return nil
 	}
-	if err := c.coreExecute(&types.SQL{
+	if err := c.coreInitDatabaseExecute(&types.SQL{
 		SQLStmt: fmt.Sprintf("DROP DATABASE %s", c.dbname),
-		SQLType: types.SQLTypeUnknown,
+		SQLType: types.SQLTypeDropDatabase,
 	}); err != nil {
 		return errors.Trace(err)
 	}
@@ -116,8 +116,8 @@ func (c *Core) clearSchema() error {
 }
 
 func (c *Core) createSchema() error {
-	return errors.Trace(c.coreExecute(&types.SQL{
+	return errors.Trace(c.coreInitDatabaseExecute(&types.SQL{
 		SQLStmt: fmt.Sprintf("CREATE DATABASE %s", c.dbname),
-		SQLType: types.SQLTypeUnknown,
+		SQLType: types.SQLTypeCreateDatabase,
 	}))
 }

--- a/pkg/pocket/pkg/types/sql.go
+++ b/pkg/pocket/pkg/types/sql.go
@@ -34,6 +34,8 @@ const (
 	SQLTypeExec
 	SQLTypeExit
 	SQLTypeSleep
+	SQLTypeCreateDatabase
+	SQLTypeDropDatabase
 )
 
 // SQL struct
@@ -78,6 +80,10 @@ func (t SQLType) String() string {
 		return "SQLTypeExit"
 	case SQLTypeSleep:
 		return "SQLTypeSleep"
+	case SQLTypeCreateDatabase:
+		return "SQLTypeCreateDatabase"
+	case SQLTypeDropDatabase:
+		return "SQLTypeDropDatabase"
 	default:
 		return "SQLTypeUnknown"
 	}

--- a/pkg/test-infra/fixture/binlog.go
+++ b/pkg/test-infra/fixture/binlog.go
@@ -13,8 +13,11 @@
 
 package fixture
 
+import "time"
+
 // BinlogConfig for binlog component
 type BinlogConfig struct {
 	BinlogVersion  string
 	EnableRelayLog bool
+	SyncTimeout    time.Duration
 }

--- a/pkg/test-infra/fixture/fixture.go
+++ b/pkg/test-infra/fixture/fixture.go
@@ -195,6 +195,8 @@ func init() {
 	flag.StringVar(&Context.TiFlashConfig.Image, "tiflash.image", "pingcap/tiflash:release-4.0", "tiflash image to use")
 	flag.StringVar(&Context.TiFlashConfig.LogPath, "tiflash.log", "", "log path for TiFlash test, default to stdout")
 
+	flag.DurationVar(&Context.BinlogConfig.SyncTimeout, "binlog.sync-timeout", time.Hour, "binlog-like job's sync timeout")
+
 	log.SetHighlighting(false)
 
 	go func() {


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

### What is changed and how does it work?

- Fix binlog workload, pocket should wait for database sync done before starting job
- Add timeout in each compare, default to 1 hour
- Add general log, sync timeout and concurrency parameters for binlog & cdc workflow
- Add concurrency parameter for abtest workflow

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Side effects

 - No

Related changes

 - No

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
