### PR TITLE
don't fatal when get/setTiDBReplicaRead failed

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -189,7 +189,7 @@ func InstallArchive(ctx context.Context, rawURL string, dest string) error {
 func getTiDBReplicaRead(job string, db *sql.DB) string {
 	var replicaRead string
 	if err := db.QueryRow("select @@tidb_replica_read").Scan(&replicaRead); err != nil {
-		log.Fatalf("[%s] get tidb_replica_read fail: %v", job, err)
+		log.Errorf("[%s] get tidb_replica_read fail: %v", job, err)
 	}
 	return replicaRead
 }
@@ -197,7 +197,7 @@ func getTiDBReplicaRead(job string, db *sql.DB) string {
 func setTiDBReplicaRead(job string, db *sql.DB, mode string) {
 	sql := fmt.Sprintf("set @@tidb_replica_read = '%s'", mode)
 	if _, err := db.Exec(sql); err != nil {
-		log.Fatalf("[%s] tidb_replica_read set fail: %v", job, err)
+		log.Errorf("[%s] tidb_replica_read set fail: %v", job, err)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Previously get/setTiDBReplicaRead fatals when it occur errors, that will terminate test.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
