### PR TITLE
Add namespace metadata label to case pod

### DIFF
--- a/argo/template/abtest.yaml
+++ b/argo/template/abtest.yaml
@@ -46,6 +46,9 @@ spec:
             default: loki
           - name: loki-password
             default: admin
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'

--- a/argo/template/bank.yaml
+++ b/argo/template/bank.yaml
@@ -43,6 +43,9 @@ spec:
           - name: case-logs
             archiveLogs: true
             path: /logs
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'

--- a/argo/template/binlog.yaml
+++ b/argo/template/binlog.yaml
@@ -34,6 +34,9 @@ spec:
             default: loki
           - name: loki-password
             default: admin
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'

--- a/argo/template/block-writer.yaml
+++ b/argo/template/block-writer.yaml
@@ -26,6 +26,9 @@ spec:
             default: loki
           - name: loki-password
             default: admin
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'

--- a/argo/template/cdc.yaml
+++ b/argo/template/cdc.yaml
@@ -46,6 +46,9 @@ spec:
             default: loki
           - name: loki-password
             default: admin
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'

--- a/argo/template/ledger.yaml
+++ b/argo/template/ledger.yaml
@@ -28,6 +28,9 @@ spec:
             default: loki
           - name: loki-password
             default: admin
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'

--- a/argo/template/rawkv-linearizability.yaml
+++ b/argo/template/rawkv-linearizability.yaml
@@ -36,6 +36,9 @@ spec:
             default: ""
           - name: tikv-replicas
             default: "3"
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'

--- a/argo/template/read-stress.yaml
+++ b/argo/template/read-stress.yaml
@@ -30,6 +30,9 @@ spec:
             default: admin
           - name: tikv-replicas
             default: "4"
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'

--- a/argo/template/region-available.yaml
+++ b/argo/template/region-available.yaml
@@ -26,6 +26,9 @@ spec:
             default: loki
           - name: loki-password
             default: admin
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'

--- a/argo/template/sc_bank.yaml
+++ b/argo/template/sc_bank.yaml
@@ -36,6 +36,9 @@ spec:
             default: "3"
           - name: tidb-replica-read
             default: "leader"
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'

--- a/argo/template/sc_bank2.yaml
+++ b/argo/template/sc_bank2.yaml
@@ -36,6 +36,9 @@ spec:
             default: "3"
           - name: tidb-replica-read
             default: "leader"
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'

--- a/argo/template/sqllogic.yaml
+++ b/argo/template/sqllogic.yaml
@@ -24,6 +24,9 @@ spec:
             default: loki
           - name: loki-password
             default: admin
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'

--- a/argo/template/tiflash.yaml
+++ b/argo/template/tiflash.yaml
@@ -30,6 +30,9 @@ spec:
             default: loki
           - name: loki-password
             default: admin
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'

--- a/argo/template/tpcc.yaml
+++ b/argo/template/tpcc.yaml
@@ -30,6 +30,9 @@ spec:
             default: loki
           - name: loki-password
             default: admin
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'

--- a/argo/template/txn-rand-pessimistic.yaml
+++ b/argo/template/txn-rand-pessimistic.yaml
@@ -26,6 +26,9 @@ spec:
             default: loki
           - name: loki-password
             default: admin
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'

--- a/argo/template/vbank.yaml
+++ b/argo/template/vbank.yaml
@@ -38,6 +38,9 @@ spec:
             default: ""
           - name: tikv-replicas
             default: "3"
+      metadata:
+        labels:
+          ns: "{{inputs.parameters.ns}}"
       container:
         name: tipocket
         image: 'pingcap/tipocket:latest'


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

This pr exposes the namespace parameter to each case, so that Prometheus can collect the namespace info for each case, then we can achieve the logs link feature in Argo.
