### PR TITLE
degrade log level when compareExecutor close failed

### DIFF
--- a/pkg/pocket/core/check.go
+++ b/pkg/pocket/core/check.go
@@ -185,7 +185,7 @@ func (c *Core) binlogTestCompareData(delay bool) (bool, error) {
 	}
 	defer func(compareExecutor *executor.Executor) {
 		if err := compareExecutor.Close(); err != nil {
-			log.Fatal("close compare executor error %+v\n", errors.ErrorStack(err))
+			log.Errorf("close compare executor error %+v\n", errors.ErrorStack(err))
 		}
 	}(compareExecutor)
 


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

When some chaos injected, it's possible occur an error when closing db.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
