### PR TITLE
Cluster: fix incorrect node port finding

### DIFF
--- a/pkg/control/control.go
+++ b/pkg/control/control.go
@@ -128,7 +128,7 @@ ROUND:
 		}
 
 		if err := c.dumpState(ctx, recorder); err != nil {
-			log.Fatalf("dump state failed %v", err)
+			log.Fatalf("dump state failed, %v", err)
 		}
 
 		// requestCount for the round, shared by all clients.
@@ -365,10 +365,7 @@ func (c *Controller) dumpState(ctx context.Context, recorder *history.Recorder) 
 		return false, nil
 	})
 
-	if err != nil {
-		return fmt.Errorf("fail to dump: %v", err)
-	}
-	return nil
+	return err
 }
 
 func (c *Controller) dispatchNemesis(ctx context.Context) {

--- a/pkg/nemesis/kill.go
+++ b/pkg/nemesis/kill.go
@@ -121,7 +121,7 @@ func findPDMember(nodes []clusterTypes.Node, ifLeader bool) []clusterTypes.Node 
 			if leader == "" && node.Client != nil {
 				leader, _, err = node.PDMember()
 				if err != nil {
-					log.Fatalf("find pd members occured an error: %+v", err)
+					log.Fatalf("find pd members occurred an error: %+v", err)
 				}
 			}
 			if ifLeader && node.PodName == leader {

--- a/pkg/test-infra/binlog/operation.go
+++ b/pkg/test-infra/binlog/operation.go
@@ -81,7 +81,7 @@ func (t *Ops) GetNodes() ([]clusterTypes.Node, error) {
 		PodName:   pod.ObjectMeta.Name,
 		IP:        pod.Status.PodIP,
 		Component: clusterTypes.Drainer,
-		Port:      util.FindPort(pod.ObjectMeta.Name, pod.Spec.Containers[0].Ports),
+		Port:      util.FindPort(pod.ObjectMeta.Name, string(clusterTypes.Drainer), pod.Spec.Containers),
 	}}, nil
 }
 

--- a/pkg/test-infra/cdc/operation.go
+++ b/pkg/test-infra/cdc/operation.go
@@ -172,6 +172,6 @@ func (o *Ops) GetNodes() ([]clusterTypes.Node, error) {
 		PodName:   pod.ObjectMeta.Name,
 		IP:        pod.Status.PodIP,
 		Component: clusterTypes.CDC,
-		Port:      util.FindPort(pod.ObjectMeta.Name, pod.Spec.Containers[0].Ports),
+		Port:      util.FindPort(pod.ObjectMeta.Name, string(clusterTypes.CDC), pod.Spec.Containers),
 	}}, nil
 }

--- a/pkg/test-infra/tidb/operation.go
+++ b/pkg/test-infra/tidb/operation.go
@@ -592,7 +592,7 @@ func (o *Ops) parseNodeFromPodList(pods *corev1.PodList) []clusterTypes.Node {
 			PodName:   pod.ObjectMeta.Name,
 			IP:        pod.Status.PodIP,
 			Component: clusterTypes.Component(component),
-			Port:      util.FindPort(pod.ObjectMeta.Name, pod.Spec.Containers[0].Ports),
+			Port:      util.FindPort(pod.ObjectMeta.Name, component, pod.Spec.Containers),
 			Client: &clusterTypes.Client{
 				Namespace:   pod.ObjectMeta.Namespace,
 				ClusterName: pod.ObjectMeta.Labels["app.kubernetes.io/instance"],

--- a/pkg/test-infra/tiflash/operation.go
+++ b/pkg/test-infra/tiflash/operation.go
@@ -130,7 +130,7 @@ func (o *Ops) GetNodes() ([]clusterTypes.Node, error) {
 			PodName:   pod.ObjectMeta.Name,
 			IP:        pod.Status.PodIP,
 			Component: clusterTypes.TiFlash,
-			Port:      util.FindPort(pod.ObjectMeta.Name, pod.Spec.Containers[0].Ports),
+			Port:      util.FindPort(pod.ObjectMeta.Name, string(clusterTypes.TiFlash), pod.Spec.Containers),
 		})
 	}
 

--- a/pkg/test-infra/util/util.go
+++ b/pkg/test-infra/util/util.go
@@ -20,6 +20,7 @@ import (
 	"html/template"
 	"strings"
 
+	"github.com/ngaut/log"
 	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
 	"github.com/pingcap/tidb-operator/pkg/controller"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	clusterTypes "github.com/pingcap/tipocket/pkg/cluster/types"
 	"github.com/pingcap/tipocket/pkg/test-infra/fixture"
 )
 
@@ -37,17 +39,26 @@ func PDAddress(tc *v1alpha1.TidbCluster) string {
 }
 
 // FindPort get possible correct port when there are multiple ports
-func FindPort(podName string, ports []corev1.ContainerPort) int32 {
-	if len(ports) == 0 {
-		return 0
+func FindPort(podName, component string, containers []corev1.Container) int32 {
+	var container *corev1.Container
+	for idx, c := range containers {
+		if c.Name == component {
+			container = &containers[idx]
+			break
+		}
 	}
-
+	// if we cannot find the target container according to component name, fallback to the first container
+	if container == nil {
+		log.Errorf("failed to find the main container %s in %s", component, podName)
+		container = &containers[0]
+	}
+	ports := container.Ports
 	var priorityPort int32 = 0
-	if strings.Contains(podName, "pd") {
+	if component == string(clusterTypes.PD) {
 		priorityPort = 2379
-	} else if strings.Contains(podName, "tikv") {
+	} else if component == string(clusterTypes.TiKV) {
 		priorityPort = 20160
-	} else if strings.Contains(podName, "tidb") {
+	} else if component == string(clusterTypes.TiDB) {
 		priorityPort = 4000
 	}
 


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

tidb-server pod has multiple containers, and the `tidb` container isn't always the first one, sometimes we may see such logs when we set port incorrectly.

```
recover nemesis type:time-chaos,duration:1m48s,node:tipocket-vbank-tidb-0 172.31.10.70:0,...
```

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
