### PR TITLE
fix more clients problem on ModeSelfScheduled mode

### DIFF
--- a/pkg/control/control.go
+++ b/pkg/control/control.go
@@ -256,6 +256,10 @@ func (c *Controller) RunSelfScheduled() {
 	}()
 
 	for i := 0; i < len(c.clients); i++ {
+		// truncate more clients
+		if i >= c.cfg.ClientCount {
+			break
+		}
 		client := c.clients[i]
 		g.Go(func() error {
 			log.Infof("run client %d...", i)


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

### What is changed and how does it work?

On CDC tests, there exist two clientNodes, upstream tidb server and downstream tidb server.

So Tipocket will create two Clients, that will occur a panic when another client try to create `pocket` database.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
