### PR TITLE
Add loki parameters to argo yaml files

### DIFF
--- a/argo/cron/bank.yaml
+++ b/argo/cron/bank.yaml
@@ -25,6 +25,12 @@ spec:
           value: "20000"
         - name: round
           value: "100"
+        - name: loki-addr
+          value: "http://gateway.loki.svc"
+        - name: loki-username
+          value: "loki"
+        - name: loki-password
+          value: "admin"
     templates:
       - name: call-tipocket-bank
         steps:
@@ -50,3 +56,9 @@ spec:
                     value: "{{workflow.parameters.request_count}}"
                   - name: round
                     value: "{{workflow.parameters.round}}"
+                  - name: loki-addr
+                    value: "{{workflow.parameters.loki-addr}}"
+                  - name: loki-username
+                    value: "{{workflow.parameters.loki-username}}"
+                  - name: loki-password
+                    value: "{{workflow.parameters.loki-password}}"

--- a/argo/cron/ledger.yaml
+++ b/argo/cron/ledger.yaml
@@ -21,6 +21,12 @@ spec:
           value: ""
         - name: run_time
           value: "60m"
+        - name: loki-addr
+          value: "http://gateway.loki.svc"
+        - name: loki-username
+          value: "loki"
+        - name: loki-password
+          value: "admin"
     templates:
       - name: call-tipocket-ledger
         steps:
@@ -42,3 +48,9 @@ spec:
                     value: "{{workflow.parameters.nemesis}}"
                   - name: run_time
                     value: "{{workflow.parameters.run_time}}"
+                  - name: loki-addr
+                    value: "{{workflow.parameters.loki-addr}}"
+                  - name: loki-username
+                    value: "{{workflow.parameters.loki-username}}"
+                  - name: loki-password
+                    value: "{{workflow.parameters.loki-password}}"

--- a/argo/cron/sc_bank.yaml
+++ b/argo/cron/sc_bank.yaml
@@ -35,6 +35,12 @@ spec:
           value: "4"
         - name: tidb-replica-read
           value: "leader-and-follower"
+        - name: loki-addr
+          value: "http://gateway.loki.svc"
+        - name: loki-username
+          value: "loki"
+        - name: loki-password
+          value: "admin"
     templates:
       - name: call-tipocket-scbank
         steps:
@@ -70,4 +76,10 @@ spec:
                     value: "{{workflow.parameters.tikv-replicas}}"
                   - name: tidb-replica-read
                     value: "{{workflow.parameters.tidb-replica-read}}"
+                  - name: loki-addr
+                    value: "{{workflow.parameters.loki-addr}}"
+                  - name: loki-username
+                    value: "{{workflow.parameters.loki-username}}"
+                  - name: loki-password
+                    value: "{{workflow.parameters.loki-password}}"
 

--- a/argo/cron/sc_bank2.yaml
+++ b/argo/cron/sc_bank2.yaml
@@ -35,6 +35,12 @@ spec:
           value: "4"
         - name: tidb-replica-read
           value: "leader-and-follower"
+        - name: loki-addr
+          value: "http://gateway.loki.svc"
+        - name: loki-username
+          value: "loki"
+        - name: loki-password
+          value: "admin"
     templates:
       - name: call-tipocket-scbank2
         steps:
@@ -70,4 +76,9 @@ spec:
                     value: "{{workflow.parameters.tikv-replicas}}"
                   - name: tidb-replica-read
                     value: "{{workflow.parameters.tidb-replica-read}}"
-
+                  - name: loki-addr
+                    value: "{{workflow.parameters.loki-addr}}"
+                  - name: loki-username
+                    value: "{{workflow.parameters.loki-username}}"
+                  - name: loki-password
+                    value: "{{workflow.parameters.loki-password}}"

--- a/argo/cron/vbank.yaml
+++ b/argo/cron/vbank.yaml
@@ -27,6 +27,12 @@ spec:
           value: "20000"
         - name: round
           value: "100"
+        - name: loki-addr
+          value: "http://gateway.loki.svc"
+        - name: loki-username
+          value: "loki"
+        - name: loki-password
+          value: "admin"
     templates:
       - name: call-tipocket-vbank
         steps:
@@ -54,3 +60,9 @@ spec:
                     value: "{{workflow.parameters.request_count}}"
                   - name: round
                     value: "{{workflow.parameters.round}}"
+                  - name: loki-addr
+                    value: "{{workflow.parameters.loki-addr}}"
+                  - name: loki-username
+                    value: "{{workflow.parameters.loki-username}}"
+                  - name: loki-password
+                    value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/abtest-chunk-rpc.yaml
+++ b/argo/workflow/abtest-chunk-rpc.yaml
@@ -35,6 +35,12 @@ spec:
         value: "3"
       - name: abtest_general_log
         value: "true"
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-abtest
       steps:
@@ -74,3 +80,9 @@ spec:
                   value: "{{workflow.parameters.abtest_concurrency}}"
                 - name: abtest_general_log
                   value: "{{workflow.parameters.abtest_general_log}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/abtest-plan-cache.yaml
+++ b/argo/workflow/abtest-plan-cache.yaml
@@ -35,6 +35,12 @@ spec:
         value: "3"
       - name: abtest_general_log
         value: "true"
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-abtest
       steps:
@@ -74,3 +80,9 @@ spec:
                   value: "{{workflow.parameters.abtest_concurrency}}"
                 - name: abtest_general_log
                   value: "{{workflow.parameters.abtest_general_log}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/abtest-tmp-storage.yaml
+++ b/argo/workflow/abtest-tmp-storage.yaml
@@ -35,6 +35,12 @@ spec:
         value: "3"
       - name: abtest_general_log
         value: "true"
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-abtest
       steps:
@@ -74,3 +80,9 @@ spec:
                   value: "{{workflow.parameters.abtest_concurrency}}"
                 - name: abtest_general_log
                   value: "{{workflow.parameters.abtest_general_log}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/abtest.yaml
+++ b/argo/workflow/abtest.yaml
@@ -35,6 +35,12 @@ spec:
         value: "3"
       - name: abtest_general_log
         value: "true"
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-abtest
       steps:
@@ -74,3 +80,9 @@ spec:
                   value: "{{workflow.parameters.abtest_concurrency}}"
                 - name: abtest_general_log
                   value: "{{workflow.parameters.abtest_general_log}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/bank-iochaos.yaml
+++ b/argo/workflow/bank-iochaos.yaml
@@ -21,6 +21,12 @@ spec:
         value: "10000"
       - name: round
         value: "100"
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-bank
       steps:
@@ -46,3 +52,9 @@ spec:
                   value: "{{workflow.parameters.request_count}}"
                 - name: round
                   value: "{{workflow.parameters.round}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/binlog.yaml
+++ b/argo/workflow/binlog.yaml
@@ -25,6 +25,12 @@ spec:
         value: "1h"
       - name: abtest_concurrency
         value: "3"
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-binlog
       steps:
@@ -54,3 +60,9 @@ spec:
                   value: "{{workflow.parameters.binlog_sync_timeout}}"
                 - name: abtest_concurrency
                   value: "{{workflow.parameters.abtest_concurrency}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/block-writer.yaml
+++ b/argo/workflow/block-writer.yaml
@@ -17,6 +17,12 @@ spec:
         value: ""
       - name: run_time
         value: "60m"
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-block-writer
       steps:
@@ -38,3 +44,9 @@ spec:
                   value: "{{workflow.parameters.nemesis}}"
                 - name: run_time
                   value: "{{workflow.parameters.run_time}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/cdc.yaml
+++ b/argo/workflow/cdc.yaml
@@ -37,6 +37,12 @@ spec:
         value: "1h"
       - name: abtest_concurrency
         value: "3"
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-cdc
       steps:
@@ -78,4 +84,9 @@ spec:
                   value: "{{workflow.parameters.binlog_sync_timeout}}"
                 - name: abtest_concurrency
                   value: "{{workflow.parameters.abtest_concurrency}}"
-
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/rawkv-linearizability.yaml
+++ b/argo/workflow/rawkv-linearizability.yaml
@@ -21,6 +21,12 @@ spec:
         value: "20000"
       - name: round
         value: "100"
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-rawkv-linearizability
       steps:
@@ -46,3 +52,9 @@ spec:
                   value: "{{workflow.parameters.request_count}}"
                 - name: round
                   value: "{{workflow.parameters.round}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/read-stress-unify-all.yaml
+++ b/argo/workflow/read-stress-unify-all.yaml
@@ -27,6 +27,12 @@ spec:
         value: loki
       - name: loki-password
         value: admin
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-read-stress
       steps:
@@ -58,3 +64,9 @@ spec:
                   value: "{{workflow.parameters.loki-password}}"
                 - name: tikv_config
                   value: "{{workflow.parameters.tikv_config}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/region-available.yaml
+++ b/argo/workflow/region-available.yaml
@@ -3,7 +3,6 @@ metadata:
   namespace: argo
 spec:
   entrypoint: call-tipocket-region-available
-
   arguments:
     parameters:
       - name: ns
@@ -11,15 +10,20 @@ spec:
       - name: purge
         value: "true"
       - name: image_version
-        value: release-4.0-nightly
+        value: nightly
       - name: storage_class
-        value: gp2
+        value: local-storage
       - name: nemesis
         value: ""
       - name: run_time
         value: "4h"
+      - name: loki-addr
+        value: "http://loki.loki.svc"
+      - name: loki-username
+        value: ""
+      - name: loki-password
+        value: ""
   templates:
-
     - name: call-tipocket-region-available
       steps:
         - - name: call-tipocket-region-available
@@ -40,3 +44,9 @@ spec:
                   value: "{{workflow.parameters.nemesis}}"
                 - name: run_time
                   value: "{{workflow.parameters.run_time}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/sqllogic.yaml
+++ b/argo/workflow/sqllogic.yaml
@@ -15,6 +15,12 @@ spec:
         value: gp2
       - name: run_time
         value: "8h"
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-sqllogic
       steps:
@@ -34,3 +40,9 @@ spec:
                   value: "{{workflow.parameters.storage_class}}"
                 - name: run_time
                   value: "{{workflow.parameters.run_time}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/tiflash-abtest.yaml
+++ b/argo/workflow/tiflash-abtest.yaml
@@ -37,6 +37,12 @@ spec:
         value: "v4.0.0-rc"
       - name: tiflash_replicas
         value: 2
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-tiflash-abtest
       steps:
@@ -78,3 +84,9 @@ spec:
                   value: "{{workflow.parameters.tiflash_image}}"
                 - name: tiflash_replicas
                   value: "{{workflow.parameters.tiflash_replicas}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/tiflash-cdc.yaml
+++ b/argo/workflow/tiflash-cdc.yaml
@@ -49,6 +49,12 @@ spec:
         value: "pingcap"
       - name: cdc_version
         value: "nightly"
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-tiflash-cdc
       steps:
@@ -102,3 +108,9 @@ spec:
                   value: "{{workflow.parameters.cdc_repository}}"
                 - name: cdc_version
                   value: "{{workflow.parameters.cdc_version}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/tiflash.yaml
+++ b/argo/workflow/tiflash.yaml
@@ -21,6 +21,12 @@ spec:
         value: "v4.0.0-rc"
       - name: tiflash_replicas
         value: 2
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-tiflash
       steps:
@@ -46,3 +52,9 @@ spec:
                   value: "{{workflow.parameters.tiflash_image}}"
                 - name: tiflash_replicas
                   value: "{{workflow.parameters.tiflash_replicas}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/tpcc.yaml
+++ b/argo/workflow/tpcc.yaml
@@ -21,6 +21,12 @@ spec:
         value: "1000000"
       - name: round
         value: "10"
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-tpcc
       steps:
@@ -46,3 +52,9 @@ spec:
                   value: "{{workflow.parameters.request_count}}"
                 - name: round
                   value: "{{workflow.parameters.round}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/argo/workflow/txn-rand-pessimistic.yaml
+++ b/argo/workflow/txn-rand-pessimistic.yaml
@@ -17,6 +17,12 @@ spec:
         value: random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler
       - name: run_time
         value: "4h"
+      - name: loki-addr
+        value: "http://gateway.loki.svc"
+      - name: loki-username
+        value: "loki"
+      - name: loki-password
+        value: "admin"
   templates:
     - name: call-tipocket-txn-rand-pessimistic
       steps:
@@ -38,3 +44,9 @@ spec:
                   value: "{{workflow.parameters.nemesis}}"
                 - name: run_time
                   value: "{{workflow.parameters.run_time}}"
+                - name: loki-addr
+                  value: "{{workflow.parameters.loki-addr}}"
+                - name: loki-username
+                  value: "{{workflow.parameters.loki-username}}"
+                - name: loki-password
+                  value: "{{workflow.parameters.loki-password}}"

--- a/pkg/test-infra/tidb/recommend.go
+++ b/pkg/test-infra/tidb/recommend.go
@@ -255,6 +255,11 @@ func RecommendedTiDBCluster(ns, name string, clusterConfig fixture.TiDBClusterCo
 
 	if clusterConfig.TiFlashReplicas > 0 {
 		r.EnableTiFlash(clusterConfig.TiFlashImageVersion, clusterConfig.TiFlashReplicas)
+		r.TidbCluster.Spec.PD.Config = &v1alpha1.PDConfig{
+			Replication: &v1alpha1.PDReplicationConfig{
+				EnablePlacementRules: pointer.BoolPtr(true),
+			},
+		}
 	}
 
 	for _, name := range strings.Split(fixture.Context.Nemesis, ",") {

--- a/pkg/test-infra/tidb/recommend.go
+++ b/pkg/test-infra/tidb/recommend.go
@@ -255,15 +255,6 @@ func RecommendedTiDBCluster(ns, name string, clusterConfig fixture.TiDBClusterCo
 
 	if clusterConfig.TiFlashReplicas > 0 {
 		r.EnableTiFlash(clusterConfig.TiFlashImageVersion, clusterConfig.TiFlashReplicas)
-
-		// TODO(yeya24): There is a bug in the operator side so we can only set it
-		// manually https://github.com/pingcap/tidb-operator/issues/2219.
-		// Remove this after it fixes the bug.
-		r.TidbCluster.Spec.PD.Config = &v1alpha1.PDConfig{
-			Replication: &v1alpha1.PDReplicationConfig{
-				EnablePlacementRules: pointer.BoolPtr(true),
-			},
-		}
 	}
 
 	for _, name := range strings.Split(fixture.Context.Nemesis, ",") {


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

This bug is fixed in the tidb-operator side, so we don't need to explicitly enable this anymore.

This PR also adds some missing part to argo yaml files