### PR TITLE
loki: fix concurrency map read and write problem

### DIFF
--- a/pkg/control/control.go
+++ b/pkg/control/control.go
@@ -54,8 +54,9 @@ type Controller struct {
 	requestCount int64
 
 	// TODO(yeya24): make log service an interface
-	lokiClient    *loki.Client
-	logPath       string
+	lokiClient *loki.Client
+	logPath    string
+	// maps from string to *os.File
 	podLogFiles   sync.Map
 	lastQueryTime time.Time
 

--- a/pkg/control/control.go
+++ b/pkg/control/control.go
@@ -56,8 +56,7 @@ type Controller struct {
 	// TODO(yeya24): make log service an interface
 	lokiClient    *loki.Client
 	logPath       string
-	mux           *sync.Mutex
-	podLogFiles   map[string]*os.File
+	podLogFiles   sync.Map
 	lastQueryTime time.Time
 
 	suit verify.Suit
@@ -85,8 +84,6 @@ func NewController(
 	c.suit = verifySuit
 	c.lokiClient = lokiCli
 	c.logPath = logPath
-	c.mux = &sync.Mutex{}
-	c.podLogFiles = make(map[string]*os.File)
 	// init time stamp
 	c.lastQueryTime = minTime
 
@@ -492,9 +489,11 @@ func (c *Controller) collectLogs() {
 			case <-c.ctx.Done():
 				c.fetchTiDBClusterLogs(c.cfg.Nodes, time.Now())
 				// Close all pod logs files
-				for _, f := range c.podLogFiles {
+				c.podLogFiles.Range(func(key, value interface{}) bool {
+					f := value.(*os.File)
 					f.Close()
-				}
+					return true
+				})
 				logTicker.Stop()
 				panicTicker.Stop()
 				return
@@ -563,17 +562,18 @@ func (c *Controller) fetchTiDBClusterLogs(nodes []clusterTypes.Node, toTime time
 				} else {
 					log.Infof("collect %s pod logs successfully, %d lines total", podName, len(texts))
 				}
-				if _, ok := c.podLogFiles[podName]; !ok {
-					c.mux.Lock()
-					c.podLogFiles[podName], err = os.OpenFile(path.Join(c.logPath, podName),
-						os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
-					c.mux.Unlock()
-					if err != nil {
-						log.Fatalf("failed to create log file for pod %s error is %v", podName, err)
-					}
+				file, err := os.OpenFile(path.Join(c.logPath, podName),
+					os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+				if err != nil {
+					log.Fatalf("failed to create log file for pod %s error is %v", podName, err)
 				}
+				f, ok := c.podLogFiles.LoadOrStore(podName, file)
+				if ok {
+					file.Close()
+				}
+				file = f.(*os.File)
 				for _, line := range texts {
-					if _, err = c.podLogFiles[podName].Write([]byte(line)); err != nil {
+					if _, err = file.Write([]byte(line)); err != nil {
 						log.Fatal("fail to write log file for pod %s error is %v", podName, err)
 					}
 				}


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

```
fatal error: concurrent map read and map write

goroutine 1302 [running]:
runtime.throw(0x1eed8ea, 0x21)
	/usr/local/go/src/runtime/panic.go:774 +0x72 fp=0xc001205cc0 sp=0xc001205c90 pc=0x42f5c2
runtime.mapaccess1_faststr(0x1bca0e0, 0xc000580900, 0xc000809980, 0x25, 0x6e)
	/usr/local/go/src/runtime/map_faststr.go:21 +0x44f fp=0xc001205d30 sp=0xc001205cc0 pc=0x412c0f
github.com/pingcap/tipocket/pkg/control.(*Controller).fetchTiDBClusterLogs.func1(0xc000da2ea0, 0xc00025c460, 0xbfa2cc1b4d540d63, 0x2d155307fd, 0x32bc220, 0xc000efc3c0, 0x13, 0xc000809980, 0x25, 0xc000e6d190, ...)
	/src/pkg/control/control.go:576 +0x3b9 fp=0xc001205f88 sp=0xc001205d30 pc=0x182b399
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc001205f90 sp=0xc001205f88 pc=0x45efb1
created by github.com/pingcap/tipocket/pkg/control.(*Controller).fetchTiDBClusterLogs
	/src/pkg/control/control.go:557 +0x22b

goroutine 1 [semacquire, 1 minutes]:
sync.runtime_Semacquire(0xc000f02040)
	/usr/local/go/src/runtime/sema.go:56 +0x42
sync.(*WaitGroup).Wait(0xc000f02038)
	/usr/local/go/src/sync/waitgroup.go:130 +0x64
golang.org/x/sync/errgroup.(*Group).Wait(0xc000f02030, 0xc000f8c000, 0xc000ec4010)
	/go/pkg/mod/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e/errgroup/errgroup.go:40 +0x31
github.com/pingcap/tipocket/pkg/control.(*Controller).RunSelfScheduled(0xc00025c460)
	/src/pkg/control/control.go:295 +0x2b0
github.com/pingcap/tipocket/pkg/control.(*Controller).Run(0xc00025c460)
	/src/pkg/control/control.go:123 +0x4e
github.com/pingcap/tipocket/cmd/util.(*Suit).Run(0xc0006edbd8, 0x21d7ea0, 0xc000056028)
	/src/cmd/util/suit.go:112 +0x79f
main.main()
	/src/cmd/cdc-pocket/main.go:63 +0x431
```

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
