### PR TITLE
Add cdc kafka consumer image flag

### DIFF
--- a/argo/cron/cdc-kafka-normal.yaml
+++ b/argo/cron/cdc-kafka-normal.yaml
@@ -41,6 +41,8 @@ spec:
           value: "master"
         - name: cdc_enable_kafka
           value: "true"
+        - name: cdc_kafka_consumer_image
+          value: "docker.io/pingcap/ticdc-kafka:nightly"
         - name: abtest_general_log
           value: "true"
         - name: binlog_sync_timeout
@@ -102,6 +104,8 @@ spec:
                     value: "{{workflow.parameters.cdc_version}}"
                   - name: cdc_enable_kafka
                     value: "{{workflow.parameters.cdc_enable_kafka}}"
+                  - name: cdc_kafka_consumer_image
+                    value: "{{workflow.parameters.cdc_kafka_consumer_image}}"
                   - name: abtest_general_log
                     value: "{{workflow.parameters.abtest_general_log}}"
                   - name: binlog_sync_timeout

--- a/argo/cron/cdc-kafka-normal.yaml
+++ b/argo/cron/cdc-kafka-normal.yaml
@@ -1,12 +1,12 @@
 metadata:
-  name: tipocket-cdc-kafka
+  name: tipocket-cdc-kafka-normal
 spec:
   schedule: "0 */6 * * *"
   concurrencyPolicy: "Forbid"
   timezone: "Asia/Shanghai"
   startingDeadlineSeconds: 0
   workflowSpec:
-    entrypoint: call-tipocket-cdc-kafka-normal
+    entrypoint: call-tipocket-cdc
     arguments:
       parameters:
         - name: ns
@@ -56,7 +56,7 @@ spec:
         - name: loki-password
           value: "admin"
     templates:
-      - name: tipocket-cdc-kafka-normal
+      - name: call-tipocket-cdc
         steps:
           - - name: call-wait-cluster
               templateRef:
@@ -66,7 +66,7 @@ spec:
                 parameters:
                   - name: ns
                     value: "{{workflow.parameters.ns}}"
-          - - name: tipocket-cdc-kafka-normal
+          - - name: call-tipocket-cdc
               templateRef:
                 name: tipocket-cdc
                 template: tipocket-cdc

--- a/argo/cron/cdc-kafka.yaml
+++ b/argo/cron/cdc-kafka.yaml
@@ -41,6 +41,8 @@ spec:
           value: "master"
         - name: cdc_enable_kafka
           value: "true"
+        - name: cdc_kafka_consumer_image
+          value: "docker.io/pingcap/ticdc-kafka:nightly"
         - name: abtest_general_log
           value: "true"
         - name: binlog_sync_timeout
@@ -102,6 +104,8 @@ spec:
                     value: "{{workflow.parameters.cdc_version}}"
                   - name: cdc_enable_kafka
                     value: "{{workflow.parameters.cdc_enable_kafka}}"
+                  - name: cdc_kafka_consumer_image
+                    value: "{{workflow.parameters.cdc_kafka_consumer_image}}"
                   - name: abtest_general_log
                     value: "{{workflow.parameters.abtest_general_log}}"
                   - name: binlog_sync_timeout

--- a/argo/cron/cdc-kafka.yaml
+++ b/argo/cron/cdc-kafka.yaml
@@ -6,7 +6,7 @@ spec:
   timezone: "Asia/Shanghai"
   startingDeadlineSeconds: 0
   workflowSpec:
-    entrypoint: call-tipocket-cdc-kafka
+    entrypoint: call-tipocket-cdc
     arguments:
       parameters:
         - name: ns
@@ -56,7 +56,7 @@ spec:
         - name: loki-password
           value: "admin"
     templates:
-      - name: tipocket-cdc-kafka
+      - name: call-tipocket-cdc
         steps:
           - - name: call-wait-cluster
               templateRef:
@@ -66,7 +66,7 @@ spec:
                 parameters:
                   - name: ns
                     value: "{{workflow.parameters.ns}}"
-          - - name: tipocket-cdc-kafka
+          - - name: call-tipocket-cdc
               templateRef:
                 name: tipocket-cdc
                 template: tipocket-cdc

--- a/argo/cron/cdc-normal.yaml
+++ b/argo/cron/cdc-normal.yaml
@@ -41,6 +41,8 @@ spec:
           value: "master"
         - name: cdc_enable_kafka
           value: "false"
+        - name: cdc_kafka_consumer_image
+          value: "docker.io/pingcap/ticdc-kafka:nightly"
         - name: abtest_general_log
           value: "true"
         - name: binlog_sync_timeout
@@ -102,6 +104,8 @@ spec:
                     value: "{{workflow.parameters.cdc_version}}"
                   - name: cdc_enable_kafka
                     value: "{{workflow.parameters.cdc_enable_kafka}}"
+                  - name: cdc_kafka_consumer_image
+                    value: "{{workflow.parameters.cdc_kafka_consumer_image}}"
                   - name: abtest_general_log
                     value: "{{workflow.parameters.abtest_general_log}}"
                   - name: binlog_sync_timeout

--- a/argo/cron/cdc.yaml
+++ b/argo/cron/cdc.yaml
@@ -41,6 +41,8 @@ spec:
           value: "master"
         - name: cdc_enable_kafka
           value: "false"
+        - name: cdc_kafka_consumer_image
+          value: "docker.io/pingcap/ticdc-kafka:nightly"
         - name: abtest_general_log
           value: "true"
         - name: binlog_sync_timeout
@@ -102,6 +104,8 @@ spec:
                     value: "{{workflow.parameters.cdc_version}}"
                   - name: cdc_enable_kafka
                     value: "{{workflow.parameters.cdc_enable_kafka}}"
+                  - name: cdc_kafka_consumer_image
+                    value: "{{workflow.parameters.cdc_kafka_consumer_image}}"
                   - name: abtest_general_log
                     value: "{{workflow.parameters.abtest_general_log}}"
                   - name: binlog_sync_timeout

--- a/argo/template/cdc.yaml
+++ b/argo/template/cdc.yaml
@@ -38,6 +38,8 @@ spec:
             default: nightly
           - name: cdc_enable_kafka
             default: "false"
+          - name: cdc_kafka_consumer_image
+            default: "docker.io/pingcap/ticdc-kafka:nightly"
           - name: abtest_general_log
             default: "true"
           - name: binlog_sync_timeout
@@ -83,6 +85,7 @@ spec:
             -cdc.repository={{inputs.parameters.cdc_repository}} \
             -cdc.version={{inputs.parameters.cdc_version}} \
             -cdc.enable-kafka={{inputs.parameters.cdc_enable_kafka}} \
+            -cdc.kafka-consumer-image={{inputs.parameters.cdc_kafka_consumer_image}} \
             -abtest.concurrency={{inputs.parameters.abtest_concurrency}} \
             -abtest.general-log={{inputs.parameters.abtest_general_log}} \
             -binlog.sync-timeout={{inputs.parameters.binlog_sync_timeout}} \

--- a/argo/workflow/cdc.yaml
+++ b/argo/workflow/cdc.yaml
@@ -37,6 +37,8 @@ spec:
         value: "nightly"
       - name: cdc_enable_kafka
         value: "false"
+      - name: cdc_kafka_consumer_image
+        value: "docker.io/pingcap/ticdc-kafka:nightly"
       - name: abtest_general_log
         value: "true"
       - name: binlog_sync_timeout
@@ -90,6 +92,8 @@ spec:
                   value: "{{workflow.parameters.cdc_version}}"
                 - name: cdc_enable_kafka
                   value: "{{workflow.parameters.cdc_enable_kafka}}"
+                - name: cdc_kafka_consumer_image
+                  value: "{{workflow.parameters.cdc_kafka_consumer_image}}"
                 - name: abtest_general_log
                   value: "{{workflow.parameters.abtest_general_log}}"
                 - name: binlog_sync_timeout

--- a/pkg/test-infra/cdc/recommend.go
+++ b/pkg/test-infra/cdc/recommend.go
@@ -378,7 +378,7 @@ func newKafka(ns, name string) *Kafka {
 						Containers: []corev1.Container{
 							{
 								Name:            "consumer",
-								Image:           buildCDCImage("cdc-kafka-consumer"),
+								Image:           fixture.Context.CDCConfig.KafkaConsumerImage,
 								ImagePullPolicy: corev1.PullAlways,
 								Command: []string{
 									"/cdc_kafka_consumer",

--- a/pkg/test-infra/fixture/cdc.go
+++ b/pkg/test-infra/fixture/cdc.go
@@ -15,11 +15,12 @@ package fixture
 
 // CDCConfig for binlog component
 type CDCConfig struct {
-	CDCVersion       string
-	DockerRepository string
-	HubAddress       string
-	LogPath          string
-	EnableKafka      bool
-	LogLevel         string
-	Timezone         string
+	CDCVersion         string
+	DockerRepository   string
+	HubAddress         string
+	LogPath            string
+	EnableKafka        bool
+	KafkaConsumerImage string
+	LogLevel           string
+	Timezone           string
 }

--- a/pkg/test-infra/fixture/fixture.go
+++ b/pkg/test-infra/fixture/fixture.go
@@ -248,6 +248,7 @@ func init() {
 	flag.StringVar(&Context.CDCConfig.HubAddress, "cdc.hub", "", `overwrite "-hub" flag for CDC`)
 	flag.StringVar(&Context.CDCConfig.LogPath, "cdc.log", "", "log path for cdc test, default to stdout")
 	flag.BoolVar(&Context.CDCConfig.EnableKafka, "cdc.enable-kafka", false, "enable kafka sink")
+	flag.StringVar(&Context.CDCConfig.KafkaConsumerImage, "cdc.kafka-consumer-image", "docker.io/pingcap/ticdc-kafka:nightly", "the kafka consumer image to use when kafka is enabled")
 	flag.StringVar(&Context.CDCConfig.LogLevel, "cdc.log-level", "debug", "log level for cdc test, default debug")
 	flag.StringVar(&Context.CDCConfig.Timezone, "cdc.timezone", "UTC", "timezone of cdc cluster, default UTC")
 


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

The consumer image has been pushed to `docker.io/pingcap/ticdc-kafka:nightly`, which is not compatible with the current repo we use. So this PR adds a flag to customized the image.
