### PR TITLE
Unify all the flags between tipocket and argo

### DIFF
--- a/argo/README.md
+++ b/argo/README.md
@@ -37,14 +37,14 @@ ServiceAccount:      default
 Status:              Pending
 Created:             Sat Mar 21 13:24:31 -0400 (1 second ago)
 Parameters:          
-  image_version:     latest
-  storage_class:     pd-ssd
+  image-version:     latest
+  storage-class:     pd-ssd
 ```
 
 ### Submit a new workflow with parameter overwritten
 
 ```bash
-argo submit workflow/bank.yaml -p image_version=nightly -n argo
+argo submit workflow/bank.yaml -p image-version=nightly -n argo
 
 Name:                tipocket-bank-xqnm2
 Namespace:           argo
@@ -52,8 +52,8 @@ ServiceAccount:      default
 Status:              Pending
 Created:             Sat Mar 21 13:32:55 -0400 (now)
 Parameters:          
-  image_version:     nightly
-  storage_class:     pd-ssd
+  image-version:     nightly
+  storage-class:     pd-ssd
 ```
 
 ### Submit a new template

--- a/argo/cron/bank.yaml
+++ b/argo/cron/bank.yaml
@@ -13,15 +13,15 @@ spec:
           value: tipocket-bank
         - name: purge
           value: "true"
-        - name: image_version
+        - name: image-version
           value: release-4.0-nightly
-        - name: storage_class
+        - name: storage-class
           value: gp2
         - name: nemesis
           value: random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler
         - name: client
           value: "5"
-        - name: request_count
+        - name: request-count
           value: "20000"
         - name: round
           value: "100"
@@ -52,16 +52,16 @@ spec:
                     value: "{{workflow.parameters.ns}}"
                   - name: purge
                     value: "{{workflow.parameters.purge}}"
-                  - name: image_version
-                    value: "{{workflow.parameters.image_version}}"
-                  - name: storage_class
-                    value: "{{workflow.parameters.storage_class}}"
+                  - name: image-version
+                    value: "{{workflow.parameters.image-version}}"
+                  - name: storage-class
+                    value: "{{workflow.parameters.storage-class}}"
                   - name: nemesis
                     value: "{{workflow.parameters.nemesis}}"
                   - name: client
                     value: "{{workflow.parameters.client}}"
-                  - name: request_count
-                    value: "{{workflow.parameters.request_count}}"
+                  - name: request-count
+                    value: "{{workflow.parameters.request-count}}"
                   - name: round
                     value: "{{workflow.parameters.round}}"
                   - name: loki-addr

--- a/argo/cron/cdc-kafka-normal.yaml
+++ b/argo/cron/cdc-kafka-normal.yaml
@@ -17,21 +17,21 @@ spec:
           value: "docker.io"
         - name: repository
           value: "pingcap"
-        - name: image_version
+        - name: image-version
           value: nightly
-        - name: tidb_image
+        - name: tidb-image
           value: ""
-        - name: tikv_image
+        - name: tikv-image
           value: "c3219bb"
-        - name: pd_image
+        - name: pd-image
           value: ""
-        - name: storage_class
+        - name: storage-class
           value: gp2
         - name: nemesis
           value: ""
-        - name: run_time
+        - name: run-time
           value: "12h"
-        - name: tikv_config
+        - name: tikv-config
           value: ""
         - name: cdc_hub
           value: "docker.io"
@@ -39,13 +39,13 @@ spec:
           value: "pingcap"
         - name: cdc_version
           value: "master"
-        - name: cdc_enable_kafka
+        - name: cdc_enable-kafka
           value: "true"
-        - name: cdc_kafka_consumer_image
+        - name: cdc_kafka-consumer-image
           value: "docker.io/pingcap/ticdc-kafka:nightly"
-        - name: abtest_general_log
+        - name: abtest_general-log
           value: "true"
-        - name: binlog_sync_timeout
+        - name: binlog_sync-timeout
           value: "30m"
         - name: abtest_concurrency
           value: "3"
@@ -80,36 +80,36 @@ spec:
                     value: "{{workflow.parameters.hub}}"
                   - name: repository
                     value: "{{workflow.parameters.repository}}"
-                  - name: image_version
-                    value: "{{workflow.parameters.image_version}}"
-                  - name: tidb_image
-                    value: "{{workflow.parameters.tidb_image}}"
-                  - name: tikv_image
-                    value: "{{workflow.parameters.tikv_image}}"
-                  - name: pd_image
-                    value: "{{workflow.parameters.pd_image}}"
-                  - name: storage_class
-                    value: "{{workflow.parameters.storage_class}}"
+                  - name: image-version
+                    value: "{{workflow.parameters.image-version}}"
+                  - name: tidb-image
+                    value: "{{workflow.parameters.tidb-image}}"
+                  - name: tikv-image
+                    value: "{{workflow.parameters.tikv-image}}"
+                  - name: pd-image
+                    value: "{{workflow.parameters.pd-image}}"
+                  - name: storage-class
+                    value: "{{workflow.parameters.storage-class}}"
                   - name: nemesis
                     value: "{{workflow.parameters.nemesis}}"
-                  - name: run_time
-                    value: "{{workflow.parameters.run_time}}"
-                  - name: tikv_config
-                    value: "{{workflow.parameters.tikv_config}}"
+                  - name: run-time
+                    value: "{{workflow.parameters.run-time}}"
+                  - name: tikv-config
+                    value: "{{workflow.parameters.tikv-config}}"
                   - name: cdc_hub
                     value: "{{workflow.parameters.cdc_hub}}"
                   - name: cdc_repository
                     value: "{{workflow.parameters.cdc_repository}}"
                   - name: cdc_version
                     value: "{{workflow.parameters.cdc_version}}"
-                  - name: cdc_enable_kafka
-                    value: "{{workflow.parameters.cdc_enable_kafka}}"
-                  - name: cdc_kafka_consumer_image
-                    value: "{{workflow.parameters.cdc_kafka_consumer_image}}"
-                  - name: abtest_general_log
-                    value: "{{workflow.parameters.abtest_general_log}}"
-                  - name: binlog_sync_timeout
-                    value: "{{workflow.parameters.binlog_sync_timeout}}"
+                  - name: cdc_enable-kafka
+                    value: "{{workflow.parameters.cdc_enable-kafka}}"
+                  - name: cdc_kafka-consumer-image
+                    value: "{{workflow.parameters.cdc_kafka-consumer-image}}"
+                  - name: abtest_general-log
+                    value: "{{workflow.parameters.abtest_general-log}}"
+                  - name: binlog_sync-timeout
+                    value: "{{workflow.parameters.binlog_sync-timeout}}"
                   - name: abtest_concurrency
                     value: "{{workflow.parameters.abtest_concurrency}}"
                   - name: loki-addr

--- a/argo/cron/cdc-kafka.yaml
+++ b/argo/cron/cdc-kafka.yaml
@@ -17,21 +17,21 @@ spec:
           value: "docker.io"
         - name: repository
           value: "pingcap"
-        - name: image_version
+        - name: image-version
           value: nightly
-        - name: tidb_image
+        - name: tidb-image
           value: ""
-        - name: tikv_image
+        - name: tikv-image
           value: "c3219bb"
-        - name: pd_image
+        - name: pd-image
           value: ""
-        - name: storage_class
+        - name: storage-class
           value: gp2
         - name: nemesis
           value: "random_kill,partition_one,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,subcritical_skews"
-        - name: run_time
+        - name: run-time
           value: "12h"
-        - name: tikv_config
+        - name: tikv-config
           value: ""
         - name: cdc_hub
           value: "docker.io"
@@ -39,13 +39,13 @@ spec:
           value: "pingcap"
         - name: cdc_version
           value: "master"
-        - name: cdc_enable_kafka
+        - name: cdc_enable-kafka
           value: "true"
-        - name: cdc_kafka_consumer_image
+        - name: cdc_kafka-consumer-image
           value: "docker.io/pingcap/ticdc-kafka:nightly"
-        - name: abtest_general_log
+        - name: abtest_general-log
           value: "true"
-        - name: binlog_sync_timeout
+        - name: binlog_sync-timeout
           value: "30m"
         - name: abtest_concurrency
           value: "3"
@@ -80,36 +80,36 @@ spec:
                     value: "{{workflow.parameters.hub}}"
                   - name: repository
                     value: "{{workflow.parameters.repository}}"
-                  - name: image_version
-                    value: "{{workflow.parameters.image_version}}"
-                  - name: tidb_image
-                    value: "{{workflow.parameters.tidb_image}}"
-                  - name: tikv_image
-                    value: "{{workflow.parameters.tikv_image}}"
-                  - name: pd_image
-                    value: "{{workflow.parameters.pd_image}}"
-                  - name: storage_class
-                    value: "{{workflow.parameters.storage_class}}"
+                  - name: image-version
+                    value: "{{workflow.parameters.image-version}}"
+                  - name: tidb-image
+                    value: "{{workflow.parameters.tidb-image}}"
+                  - name: tikv-image
+                    value: "{{workflow.parameters.tikv-image}}"
+                  - name: pd-image
+                    value: "{{workflow.parameters.pd-image}}"
+                  - name: storage-class
+                    value: "{{workflow.parameters.storage-class}}"
                   - name: nemesis
                     value: "{{workflow.parameters.nemesis}}"
-                  - name: run_time
-                    value: "{{workflow.parameters.run_time}}"
-                  - name: tikv_config
-                    value: "{{workflow.parameters.tikv_config}}"
+                  - name: run-time
+                    value: "{{workflow.parameters.run-time}}"
+                  - name: tikv-config
+                    value: "{{workflow.parameters.tikv-config}}"
                   - name: cdc_hub
                     value: "{{workflow.parameters.cdc_hub}}"
                   - name: cdc_repository
                     value: "{{workflow.parameters.cdc_repository}}"
                   - name: cdc_version
                     value: "{{workflow.parameters.cdc_version}}"
-                  - name: cdc_enable_kafka
-                    value: "{{workflow.parameters.cdc_enable_kafka}}"
-                  - name: cdc_kafka_consumer_image
-                    value: "{{workflow.parameters.cdc_kafka_consumer_image}}"
-                  - name: abtest_general_log
-                    value: "{{workflow.parameters.abtest_general_log}}"
-                  - name: binlog_sync_timeout
-                    value: "{{workflow.parameters.binlog_sync_timeout}}"
+                  - name: cdc_enable-kafka
+                    value: "{{workflow.parameters.cdc_enable-kafka}}"
+                  - name: cdc_kafka-consumer-image
+                    value: "{{workflow.parameters.cdc_kafka-consumer-image}}"
+                  - name: abtest_general-log
+                    value: "{{workflow.parameters.abtest_general-log}}"
+                  - name: binlog_sync-timeout
+                    value: "{{workflow.parameters.binlog_sync-timeout}}"
                   - name: abtest_concurrency
                     value: "{{workflow.parameters.abtest_concurrency}}"
                   - name: loki-addr

--- a/argo/cron/cdc-normal.yaml
+++ b/argo/cron/cdc-normal.yaml
@@ -17,21 +17,21 @@ spec:
           value: "docker.io"
         - name: repository
           value: "pingcap"
-        - name: image_version
+        - name: image-version
           value: nightly
-        - name: tidb_image
+        - name: tidb-image
           value: ""
-        - name: tikv_image
+        - name: tikv-image
           value: "c3219bb"
-        - name: pd_image
+        - name: pd-image
           value: ""
-        - name: storage_class
+        - name: storage-class
           value: gp2
         - name: nemesis
           value: ""
-        - name: run_time
+        - name: run-time
           value: "12h"
-        - name: tikv_config
+        - name: tikv-config
           value: ""
         - name: cdc_hub
           value: "docker.io"
@@ -39,13 +39,13 @@ spec:
           value: "pingcap"
         - name: cdc_version
           value: "master"
-        - name: cdc_enable_kafka
+        - name: cdc_enable-kafka
           value: "false"
-        - name: cdc_kafka_consumer_image
+        - name: cdc_kafka-consumer-image
           value: "docker.io/pingcap/ticdc-kafka:nightly"
-        - name: abtest_general_log
+        - name: abtest_general-log
           value: "true"
-        - name: binlog_sync_timeout
+        - name: binlog_sync-timeout
           value: "30m"
         - name: abtest_concurrency
           value: "3"
@@ -80,36 +80,36 @@ spec:
                     value: "{{workflow.parameters.hub}}"
                   - name: repository
                     value: "{{workflow.parameters.repository}}"
-                  - name: image_version
-                    value: "{{workflow.parameters.image_version}}"
-                  - name: tidb_image
-                    value: "{{workflow.parameters.tidb_image}}"
-                  - name: tikv_image
-                    value: "{{workflow.parameters.tikv_image}}"
-                  - name: pd_image
-                    value: "{{workflow.parameters.pd_image}}"
-                  - name: storage_class
-                    value: "{{workflow.parameters.storage_class}}"
+                  - name: image-version
+                    value: "{{workflow.parameters.image-version}}"
+                  - name: tidb-image
+                    value: "{{workflow.parameters.tidb-image}}"
+                  - name: tikv-image
+                    value: "{{workflow.parameters.tikv-image}}"
+                  - name: pd-image
+                    value: "{{workflow.parameters.pd-image}}"
+                  - name: storage-class
+                    value: "{{workflow.parameters.storage-class}}"
                   - name: nemesis
                     value: "{{workflow.parameters.nemesis}}"
-                  - name: run_time
-                    value: "{{workflow.parameters.run_time}}"
-                  - name: tikv_config
-                    value: "{{workflow.parameters.tikv_config}}"
+                  - name: run-time
+                    value: "{{workflow.parameters.run-time}}"
+                  - name: tikv-config
+                    value: "{{workflow.parameters.tikv-config}}"
                   - name: cdc_hub
                     value: "{{workflow.parameters.cdc_hub}}"
                   - name: cdc_repository
                     value: "{{workflow.parameters.cdc_repository}}"
                   - name: cdc_version
                     value: "{{workflow.parameters.cdc_version}}"
-                  - name: cdc_enable_kafka
-                    value: "{{workflow.parameters.cdc_enable_kafka}}"
-                  - name: cdc_kafka_consumer_image
-                    value: "{{workflow.parameters.cdc_kafka_consumer_image}}"
-                  - name: abtest_general_log
-                    value: "{{workflow.parameters.abtest_general_log}}"
-                  - name: binlog_sync_timeout
-                    value: "{{workflow.parameters.binlog_sync_timeout}}"
+                  - name: cdc_enable-kafka
+                    value: "{{workflow.parameters.cdc_enable-kafka}}"
+                  - name: cdc_kafka-consumer-image
+                    value: "{{workflow.parameters.cdc_kafka-consumer-image}}"
+                  - name: abtest_general-log
+                    value: "{{workflow.parameters.abtest_general-log}}"
+                  - name: binlog_sync-timeout
+                    value: "{{workflow.parameters.binlog_sync-timeout}}"
                   - name: abtest_concurrency
                     value: "{{workflow.parameters.abtest_concurrency}}"
                   - name: loki-addr

--- a/argo/cron/cdc.yaml
+++ b/argo/cron/cdc.yaml
@@ -17,21 +17,21 @@ spec:
           value: "docker.io"
         - name: repository
           value: "pingcap"
-        - name: image_version
+        - name: image-version
           value: nightly
-        - name: tidb_image
+        - name: tidb-image
           value: ""
-        - name: tikv_image
+        - name: tikv-image
           value: "c3219bb"
-        - name: pd_image
+        - name: pd-image
           value: ""
-        - name: storage_class
+        - name: storage-class
           value: gp2
         - name: nemesis
           value: "random_kill,partition_one,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,subcritical_skews"
-        - name: run_time
+        - name: run-time
           value: "12h"
-        - name: tikv_config
+        - name: tikv-config
           value: ""
         - name: cdc_hub
           value: "docker.io"
@@ -39,13 +39,13 @@ spec:
           value: "pingcap"
         - name: cdc_version
           value: "master"
-        - name: cdc_enable_kafka
+        - name: cdc_enable-kafka
           value: "false"
-        - name: cdc_kafka_consumer_image
+        - name: cdc_kafka-consumer-image
           value: "docker.io/pingcap/ticdc-kafka:nightly"
-        - name: abtest_general_log
+        - name: abtest_general-log
           value: "true"
-        - name: binlog_sync_timeout
+        - name: binlog_sync-timeout
           value: "30m"
         - name: abtest_concurrency
           value: "3"
@@ -80,36 +80,36 @@ spec:
                     value: "{{workflow.parameters.hub}}"
                   - name: repository
                     value: "{{workflow.parameters.repository}}"
-                  - name: image_version
-                    value: "{{workflow.parameters.image_version}}"
-                  - name: tidb_image
-                    value: "{{workflow.parameters.tidb_image}}"
-                  - name: tikv_image
-                    value: "{{workflow.parameters.tikv_image}}"
-                  - name: pd_image
-                    value: "{{workflow.parameters.pd_image}}"
-                  - name: storage_class
-                    value: "{{workflow.parameters.storage_class}}"
+                  - name: image-version
+                    value: "{{workflow.parameters.image-version}}"
+                  - name: tidb-image
+                    value: "{{workflow.parameters.tidb-image}}"
+                  - name: tikv-image
+                    value: "{{workflow.parameters.tikv-image}}"
+                  - name: pd-image
+                    value: "{{workflow.parameters.pd-image}}"
+                  - name: storage-class
+                    value: "{{workflow.parameters.storage-class}}"
                   - name: nemesis
                     value: "{{workflow.parameters.nemesis}}"
-                  - name: run_time
-                    value: "{{workflow.parameters.run_time}}"
-                  - name: tikv_config
-                    value: "{{workflow.parameters.tikv_config}}"
+                  - name: run-time
+                    value: "{{workflow.parameters.run-time}}"
+                  - name: tikv-config
+                    value: "{{workflow.parameters.tikv-config}}"
                   - name: cdc_hub
                     value: "{{workflow.parameters.cdc_hub}}"
                   - name: cdc_repository
                     value: "{{workflow.parameters.cdc_repository}}"
                   - name: cdc_version
                     value: "{{workflow.parameters.cdc_version}}"
-                  - name: cdc_enable_kafka
-                    value: "{{workflow.parameters.cdc_enable_kafka}}"
-                  - name: cdc_kafka_consumer_image
-                    value: "{{workflow.parameters.cdc_kafka_consumer_image}}"
-                  - name: abtest_general_log
-                    value: "{{workflow.parameters.abtest_general_log}}"
-                  - name: binlog_sync_timeout
-                    value: "{{workflow.parameters.binlog_sync_timeout}}"
+                  - name: cdc_enable-kafka
+                    value: "{{workflow.parameters.cdc_enable-kafka}}"
+                  - name: cdc_kafka-consumer-image
+                    value: "{{workflow.parameters.cdc_kafka-consumer-image}}"
+                  - name: abtest_general-log
+                    value: "{{workflow.parameters.abtest_general-log}}"
+                  - name: binlog_sync-timeout
+                    value: "{{workflow.parameters.binlog_sync-timeout}}"
                   - name: abtest_concurrency
                     value: "{{workflow.parameters.abtest_concurrency}}"
                   - name: loki-addr

--- a/argo/cron/ledger.yaml
+++ b/argo/cron/ledger.yaml
@@ -13,13 +13,13 @@ spec:
           value: tipocket-ledger
         - name: purge
           value: "true"
-        - name: image_version
+        - name: image-version
           value: release-4.0-nightly
-        - name: storage_class
+        - name: storage-class
           value: gp2
         - name: nemesis
           value: ""
-        - name: run_time
+        - name: run-time
           value: "60m"
         - name: loki-addr
           value: "http://gateway.loki.svc"
@@ -48,14 +48,14 @@ spec:
                     value: "{{workflow.parameters.ns}}"
                   - name: purge
                     value: "{{workflow.parameters.purge}}"
-                  - name: image_version
-                    value: "{{workflow.parameters.image_version}}"
-                  - name: storage_class
-                    value: "{{workflow.parameters.storage_class}}"
+                  - name: image-version
+                    value: "{{workflow.parameters.image-version}}"
+                  - name: storage-class
+                    value: "{{workflow.parameters.storage-class}}"
                   - name: nemesis
                     value: "{{workflow.parameters.nemesis}}"
-                  - name: run_time
-                    value: "{{workflow.parameters.run_time}}"
+                  - name: run-time
+                    value: "{{workflow.parameters.run-time}}"
                   - name: loki-addr
                     value: "{{workflow.parameters.loki-addr}}"
                   - name: loki-username

--- a/argo/cron/list-append.yaml
+++ b/argo/cron/list-append.yaml
@@ -21,15 +21,15 @@ spec:
           value: "true"
         - name: repository
           value: pingcap
-        - name: image_version
+        - name: image-version
           value: nightly
-        - name: storage_class
+        - name: storage-class
           value: gp2
         - name: nemesis
           value: "random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler"
         - name: client
           value: "5"
-        - name: request_count
+        - name: request-count
           value: "100000"
         - name: round
           value: "10"
@@ -68,16 +68,16 @@ spec:
                     value: "{{workflow.parameters.purge}}"
                   - name: repository
                     value: "{{workflow.parameters.repository}}"
-                  - name: image_version
-                    value: "{{workflow.parameters.image_version}}"
-                  - name: storage_class
-                    value: "{{workflow.parameters.storage_class}}"
+                  - name: image-version
+                    value: "{{workflow.parameters.image-version}}"
+                  - name: storage-class
+                    value: "{{workflow.parameters.storage-class}}"
                   - name: nemesis
                     value: "{{workflow.parameters.nemesis}}"
                   - name: client
                     value: "{{workflow.parameters.client}}"
-                  - name: request_count
-                    value: "{{workflow.parameters.request_count}}"
+                  - name: request-count
+                    value: "{{workflow.parameters.request-count}}"
                   - name: round
                     value: "{{workflow.parameters.round}}"
                   - name: loki-addr

--- a/argo/cron/sc_bank.yaml
+++ b/argo/cron/sc_bank.yaml
@@ -13,17 +13,17 @@ spec:
           value: tipocket-scbank
         - name: purge
           value: "true"
-        - name: image_version
+        - name: image-version
           value: release-4.0-nightly
-        - name: storage_class
+        - name: storage-class
           value: gp2
         - name: nemesis
           value: "random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler"
-        - name: tidb_config
+        - name: tidb-config
           value: ""
-        - name: tikv_config
+        - name: tikv-config
           value: ""
-        - name: pd_config
+        - name: pd-config
           value: ""
         - name: tikv-replicas
           value: "4"
@@ -56,18 +56,18 @@ spec:
                     value: "{{workflow.parameters.ns}}"
                   - name: purge
                     value: "{{workflow.parameters.purge}}"
-                  - name: image_version
-                    value: "{{workflow.parameters.image_version}}"
-                  - name: storage_class
-                    value: "{{workflow.parameters.storage_class}}"
+                  - name: image-version
+                    value: "{{workflow.parameters.image-version}}"
+                  - name: storage-class
+                    value: "{{workflow.parameters.storage-class}}"
                   - name: nemesis
                     value: "{{workflow.parameters.nemesis}}"
-                  - name: tidb_config
-                    value: "{{workflow.parameters.tidb_config}}"
-                  - name: tikv_config
-                    value: "{{workflow.parameters.tikv_config}}"
-                  - name: pd_config
-                    value: "{{workflow.parameters.pd_config}}"
+                  - name: tidb-config
+                    value: "{{workflow.parameters.tidb-config}}"
+                  - name: tikv-config
+                    value: "{{workflow.parameters.tikv-config}}"
+                  - name: pd-config
+                    value: "{{workflow.parameters.pd-config}}"
                   - name: loki-addr
                     value: "{{workflow.parameters.loki-addr}}"
                   - name: loki-username

--- a/argo/cron/sc_bank2.yaml
+++ b/argo/cron/sc_bank2.yaml
@@ -13,17 +13,17 @@ spec:
           value: tipocket-scbank2
         - name: purge
           value: "true"
-        - name: image_version
+        - name: image-version
           value: release-4.0-nightly
-        - name: storage_class
+        - name: storage-class
           value: gp2
         - name: nemesis
           value: "random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler"
-        - name: tidb_config
+        - name: tidb-config
           value: ""
-        - name: tikv_config
+        - name: tikv-config
           value: ""
-        - name: pd_config
+        - name: pd-config
           value: ""
         - name: tikv-replicas
           value: "4"
@@ -56,18 +56,18 @@ spec:
                     value: "{{workflow.parameters.ns}}"
                   - name: purge
                     value: "{{workflow.parameters.purge}}"
-                  - name: image_version
-                    value: "{{workflow.parameters.image_version}}"
-                  - name: storage_class
-                    value: "{{workflow.parameters.storage_class}}"
+                  - name: image-version
+                    value: "{{workflow.parameters.image-version}}"
+                  - name: storage-class
+                    value: "{{workflow.parameters.storage-class}}"
                   - name: nemesis
                     value: "{{workflow.parameters.nemesis}}"
-                  - name: tidb_config
-                    value: "{{workflow.parameters.tidb_config}}"
-                  - name: tikv_config
-                    value: "{{workflow.parameters.tikv_config}}"
-                  - name: pd_config
-                    value: "{{workflow.parameters.pd_config}}"
+                  - name: tidb-config
+                    value: "{{workflow.parameters.tidb-config}}"
+                  - name: tikv-config
+                    value: "{{workflow.parameters.tikv-config}}"
+                  - name: pd-config
+                    value: "{{workflow.parameters.pd-config}}"
                   - name: loki-addr
                     value: "{{workflow.parameters.loki-addr}}"
                   - name: loki-username

--- a/argo/cron/vbank.yaml
+++ b/argo/cron/vbank.yaml
@@ -15,15 +15,15 @@ spec:
           value: "true"
         - name: repository
           value: pingcap
-        - name: image_version
+        - name: image-version
           value: nightly
-        - name: storage_class
+        - name: storage-class
           value: gp2
         - name: nemesis
           value: "random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler"
         - name: client
           value: "5"
-        - name: request_count
+        - name: request-count
           value: "20000"
         - name: round
           value: "100"
@@ -56,16 +56,16 @@ spec:
                     value: "{{workflow.parameters.purge}}"
                   - name: repository
                     value: "{{workflow.parameters.repository}}"
-                  - name: image_version
-                    value: "{{workflow.parameters.image_version}}"
-                  - name: storage_class
-                    value: "{{workflow.parameters.storage_class}}"
+                  - name: image-version
+                    value: "{{workflow.parameters.image-version}}"
+                  - name: storage-class
+                    value: "{{workflow.parameters.storage-class}}"
                   - name: nemesis
                     value: "{{workflow.parameters.nemesis}}"
                   - name: client
                     value: "{{workflow.parameters.client}}"
-                  - name: request_count
-                    value: "{{workflow.parameters.request_count}}"
+                  - name: request-count
+                    value: "{{workflow.parameters.request-count}}"
                   - name: round
                     value: "{{workflow.parameters.round}}"
                   - name: loki-addr

--- a/argo/template/abtest.yaml
+++ b/argo/template/abtest.yaml
@@ -14,33 +14,33 @@ spec:
             default: "false"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: abtest_version
+          - name: abtest_image-version
             value: latest
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: ""
           - name: client
             default: "2"
-          - name: run_time
+          - name: run-time
             default: "48h"
-          - name: tidb_config
+          - name: tidb-config
             default: ""
-          - name: tikv_config
+          - name: tikv-config
             default: ""
-          - name: pd_config
+          - name: pd-config
             default: ""
-          - name: abtest_tidb_config
+          - name: abtest_tidb-config
             default: ""
-          - name: abtest_tikv_config
+          - name: abtest_tikv-config
             default: ""
-          - name: abtest_pd_config
+          - name: abtest_pd-config
             default: ""
           - name: abtest_concurrency
             default: "3"
-          - name: abtest_general_log
+          - name: abtest_general-log
             default: "true"
           - name: loki-addr
             default: http://gateway.loki.svc
@@ -67,22 +67,22 @@ spec:
             /bin/abtest \
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
-            -storage-class={{inputs.parameters.storage_class}} \
+            -storage-class={{inputs.parameters.storage-class}} \
             -repository={{inputs.parameters.repository}} \
-            -image-version={{inputs.parameters.image_version}} \
-            -abtest.image-version={{inputs.parameters.abtest_version}} \
+            -image-version={{inputs.parameters.image-version}} \
+            -abtest.image-version={{inputs.parameters.abtest_image-version}} \
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
             -client={{inputs.parameters.client}} \
-            -run-time={{inputs.parameters.run_time}} \
-            -tidb-config={{inputs.parameters.tidb_config}} \
-            -tikv-config={{inputs.parameters.tikv_config}} \
-            -pd-config={{inputs.parameters.pd_config}} \
-            -abtest.tidb-config={{inputs.parameters.abtest_tidb_config}} \
-            -abtest.tikv-config={{inputs.parameters.abtest_tikv_config}} \
-            -abtest.pd-config={{inputs.parameters.abtest_pd_config}} \
+            -run-time={{inputs.parameters.run-time}} \
+            -tidb-config={{inputs.parameters.tidb-config}} \
+            -tikv-config={{inputs.parameters.tikv-config}} \
+            -pd-config={{inputs.parameters.pd-config}} \
+            -abtest.tidb-config={{inputs.parameters.abtest_tidb-config}} \
+            -abtest.tikv-config={{inputs.parameters.abtest_tikv-config}} \
+            -abtest.pd-config={{inputs.parameters.abtest_pd-config}} \
             -abtest.concurrency={{inputs.parameters.abtest_concurrency}} \
-            -abtest.general-log={{inputs.parameters.abtest_general_log}} \
+            -abtest.general-log={{inputs.parameters.abtest_general-log}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/bank.yaml
+++ b/argo/template/bank.yaml
@@ -14,15 +14,15 @@ spec:
             default: "false"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: "random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler"
           - name: client
             default: "5"
-          - name: request_count
+          - name: request-count
             default: "10000"
           - name: round
             default: "100"
@@ -32,11 +32,11 @@ spec:
             default: loki
           - name: loki-password
             default: admin
-          - name: tidb_config
+          - name: tidb-config
             default: ""
-          - name: tikv_config
+          - name: tikv-config
             default: ""
-          - name: pd_config
+          - name: pd-config
             default: ""
           - name: tikv-replicas
             default: "4"
@@ -63,18 +63,18 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
             -purge={{inputs.parameters.purge}} \
             -case=bank \
             -client={{inputs.parameters.client}} \
-            -tidb-config={{inputs.parameters.tidb_config}} \
-            -tikv-config={{inputs.parameters.tikv_config}} \
-            -pd-config={{inputs.parameters.pd_config}} \
+            -tidb-config={{inputs.parameters.tidb-config}} \
+            -tikv-config={{inputs.parameters.tikv-config}} \
+            -pd-config={{inputs.parameters.pd-config}} \
             -tikv-replicas={{inputs.parameters.tikv-replicas}} \
             -nemesis={{inputs.parameters.nemesis}} \
             -round={{inputs.parameters.round}} \
-            -request-count={{inputs.parameters.request_count}} \
+            -request-count={{inputs.parameters.request-count}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/bank.yaml
+++ b/argo/template/bank.yaml
@@ -55,6 +55,7 @@ spec:
         name: tipocket
         image: 'pingcap/tipocket:latest'
         imagePullPolicy: Always
+        workingDir: /logs
         command:
           - sh
           - '-c'

--- a/argo/template/binlog.yaml
+++ b/argo/template/binlog.yaml
@@ -14,21 +14,21 @@ spec:
             default: "false"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: ""
-          - name: run_time
+          - name: run-time
             default: "48h"
-          - name: relay_log
+          - name: relay-log
             default: "true"
-          - name: abtest_general_log
+          - name: abtest_general-log
             default: "true"
           - name: abtest_concurrency
             default: "3"
-          - name: binlog_sync_timeout
+          - name: binlog_sync-timeout
             default: "1h"
           - name: loki-addr
             default: http://gateway.loki.svc
@@ -56,15 +56,15 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
-            -run-time={{inputs.parameters.run_time}} \
-            -relay-log={{inputs.parameters.relay_log}} \
+            -run-time={{inputs.parameters.run-time}} \
+            -relay-log={{inputs.parameters.relay-log}} \
             -abtest.concurrency={{inputs.parameters.abtest_concurrency}} \
-            -abtest.general-log={{inputs.parameters.abtest_general_log}} \
-            -binlog.sync-timeout={{inputs.parameters.binlog_sync_timeout}} \
+            -abtest.general-log={{inputs.parameters.abtest_general-log}} \
+            -binlog.sync-timeout={{inputs.parameters.binlog_sync-timeout}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/block-writer.yaml
+++ b/argo/template/block-writer.yaml
@@ -14,13 +14,13 @@ spec:
             default: "false"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: ""
-          - name: run_time
+          - name: run-time
             default: "60m"
           - name: loki-addr
             default: http://gateway.loki.svc
@@ -48,11 +48,11 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
-            -run-time={{inputs.parameters.run_time}} \
+            -run-time={{inputs.parameters.run-time}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/cdc.yaml
+++ b/argo/template/cdc.yaml
@@ -14,21 +14,21 @@ spec:
             default: "docker.io"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: tidb_image
+          - name: tidb-image
             default: ""
-          - name: tikv_image
+          - name: tikv-image
             default: ""
-          - name: pd_image
+          - name: pd-image
             default: ""
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: ""
-          - name: run_time
+          - name: run-time
             default: "48h"
-          - name: tikv_config
+          - name: tikv-config
             default: ""
           - name: cdc_hub
             default: docker.io
@@ -36,13 +36,13 @@ spec:
             default: pingcap
           - name: cdc_version
             default: nightly
-          - name: cdc_enable_kafka
+          - name: cdc_enable-kafka
             default: "false"
-          - name: cdc_kafka_consumer_image
+          - name: cdc_kafka-consumer-image
             default: "docker.io/pingcap/ticdc-kafka:nightly"
-          - name: abtest_general_log
+          - name: abtest_general-log
             default: "true"
-          - name: binlog_sync_timeout
+          - name: binlog_sync-timeout
             default: "1h"
           - name: abtest_concurrency
             default: "3"
@@ -72,23 +72,23 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
-            -tidb-image={{inputs.parameters.tidb_image}} \
-            -tikv-image={{inputs.parameters.tikv_image}} \
-            -pd-image={{inputs.parameters.pd_image}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
+            -tidb-image={{inputs.parameters.tidb-image}} \
+            -tikv-image={{inputs.parameters.tikv-image}} \
+            -pd-image={{inputs.parameters.pd-image}} \
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
-            -run-time={{inputs.parameters.run_time}} \
-            -tikv-config={{inputs.parameters.tikv_config}} \
+            -run-time={{inputs.parameters.run-time}} \
+            -tikv-config={{inputs.parameters.tikv-config}} \
             -cdc.hub={{inputs.parameters.cdc_hub}} \
             -cdc.repository={{inputs.parameters.cdc_repository}} \
             -cdc.version={{inputs.parameters.cdc_version}} \
-            -cdc.enable-kafka={{inputs.parameters.cdc_enable_kafka}} \
-            -cdc.kafka-consumer-image={{inputs.parameters.cdc_kafka_consumer_image}} \
+            -cdc.enable-kafka={{inputs.parameters.cdc_enable-kafka}} \
+            -cdc.kafka-consumer-image={{inputs.parameters.cdc_kafka-consumer-image}} \
             -abtest.concurrency={{inputs.parameters.abtest_concurrency}} \
-            -abtest.general-log={{inputs.parameters.abtest_general_log}} \
-            -binlog.sync-timeout={{inputs.parameters.binlog_sync_timeout}} \
+            -abtest.general-log={{inputs.parameters.abtest_general-log}} \
+            -binlog.sync-timeout={{inputs.parameters.binlog_sync-timeout}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/follower-read.yaml
+++ b/argo/template/follower-read.yaml
@@ -14,13 +14,13 @@ spec:
             default: "true"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: "random_kill, partition_one, shuffle-leader-scheduler"
-          - name: run_time
+          - name: run-time
             default: "6h"
           - name: loki-addr
             default: http://gateway.loki.svc
@@ -28,11 +28,11 @@ spec:
             default: loki
           - name: loki-password
             default: admin
-          - name: tidb_config
+          - name: tidb-config
             default: ""
-          - name: tikv_config
+          - name: tikv-config
             default: ""
-          - name: pd_config
+          - name: pd-config
             default: ""
           - name: tikv-replicas
             default: "5"
@@ -55,14 +55,14 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
             -purge={{inputs.parameters.purge}} \
-            -tidb-config={{inputs.parameters.tidb_config}} \
-            -tikv-config={{inputs.parameters.tikv_config}} \
-            -pd-config={{inputs.parameters.pd_config}} \
+            -tidb-config={{inputs.parameters.tidb-config}} \
+            -tikv-config={{inputs.parameters.tikv-config}} \
+            -pd-config={{inputs.parameters.pd-config}} \
             -nemesis={{inputs.parameters.nemesis}} \
-            -run-time={{inputs.parameters.run_time}} \
+            -run-time={{inputs.parameters.run-time}} \
             -tikv-replicas={{inputs.parameters.tikv-replicas}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \

--- a/argo/template/ledger.yaml
+++ b/argo/template/ledger.yaml
@@ -14,13 +14,13 @@ spec:
             default: "false"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: ""
-          - name: run_time
+          - name: run-time
             default: "5h"
           - name: tikv-replicas
             default: "4"
@@ -50,11 +50,11 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
-            -run-time={{inputs.parameters.run_time}} \
+            -run-time={{inputs.parameters.run-time}} \
             -tikv-replicas={{inputs.parameters.tikv-replicas}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \

--- a/argo/template/list-append.yaml
+++ b/argo/template/list-append.yaml
@@ -20,15 +20,15 @@ spec:
             default: "false"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: "random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler"
           - name: client
             default: "5"
-          - name: request_count
+          - name: request-count
             default: "10000"
           - name: round
             default: "1"
@@ -38,11 +38,11 @@ spec:
             default: loki
           - name: loki-password
             default: admin
-          - name: tidb_config
+          - name: tidb-config
             default: ""
-          - name: tikv_config
+          - name: tikv-config
             default: ""
-          - name: pd_config
+          - name: pd-config
             default: ""
           - name: tikv-replicas
             default: "4"
@@ -73,17 +73,17 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
-            -tidb-config={{inputs.parameters.tidb_config}} \
-            -tikv-config={{inputs.parameters.tikv_config}} \
-            -pd-config={{inputs.parameters.pd_config}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
+            -tidb-config={{inputs.parameters.tidb-config}} \
+            -tikv-config={{inputs.parameters.tikv-config}} \
+            -pd-config={{inputs.parameters.pd-config}} \
             -purge={{inputs.parameters.purge}} \
             -client={{inputs.parameters.client}} \
             -tikv-replicas={{inputs.parameters.tikv-replicas}} \
             -nemesis={{inputs.parameters.nemesis}} \
             -round={{inputs.parameters.round}} \
-            -request-count={{inputs.parameters.request_count}} \
+            -request-count={{inputs.parameters.request-count}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/rawkv-linearizability.yaml
+++ b/argo/template/rawkv-linearizability.yaml
@@ -12,15 +12,15 @@ spec:
             default: "docker.io"
           - name: purge
             default: "false"
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: "random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler"
           - name: client
             default: "5"
-          - name: request_count
+          - name: request-count
             default: "10000"
           - name: round
             default: "100"
@@ -30,11 +30,11 @@ spec:
             default: loki
           - name: loki-password
             default: admin
-          - name: tidb_config
+          - name: tidb-config
             default: ""
-          - name: tikv_config
+          - name: tikv-config
             default: ""
-          - name: pd_config
+          - name: pd-config
             default: ""
           - name: tikv-replicas
             default: "3"
@@ -61,17 +61,17 @@ spec:
             /bin/rawkv-linearizability \
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
-            -tidb-config={{inputs.parameters.tidb_config}} \
-            -tikv-config={{inputs.parameters.tikv_config}} \
-            -pd-config={{inputs.parameters.pd_config}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
+            -tidb-config={{inputs.parameters.tidb-config}} \
+            -tikv-config={{inputs.parameters.tikv-config}} \
+            -pd-config={{inputs.parameters.pd-config}} \
             -purge={{inputs.parameters.purge}} \
             -client={{inputs.parameters.client}} \
             -tikv-replicas={{inputs.parameters.tikv-replicas}} \
             -nemesis={{inputs.parameters.nemesis}} \
             -round={{inputs.parameters.round}} \
-            -request-count={{inputs.parameters.request_count}} \
+            -request-count={{inputs.parameters.request-count}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/read-stress.yaml
+++ b/argo/template/read-stress.yaml
@@ -14,15 +14,15 @@ spec:
             default: "true"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: "random_kill, partition_one, shuffle-leader-scheduler"
-          - name: run_time
+          - name: run-time
             default: "6h"
-          - name: tikv_config
+          - name: tikv-config
             default: ""
           - name: loki-addr
             default: http://gateway.loki.svc
@@ -53,13 +53,13 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
-            -run-time={{inputs.parameters.run_time}} \
+            -run-time={{inputs.parameters.run-time}} \
             -tikv-replicas={{inputs.parameters.tikv-replicas}} \
-            -tikv-config={{inputs.parameters.tikv_config}} \
+            -tikv-config={{inputs.parameters.tikv-config}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}} \

--- a/argo/template/region-available.yaml
+++ b/argo/template/region-available.yaml
@@ -14,13 +14,13 @@ spec:
             default: "false"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: ""
-          - name: run_time
+          - name: run-time
             default: "4h"
           - name: loki-addr
             default: http://gateway.loki.svc
@@ -48,11 +48,11 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
-            -run-time={{inputs.parameters.run_time}} \
+            -run-time={{inputs.parameters.run-time}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/sc_bank.yaml
+++ b/argo/template/sc_bank.yaml
@@ -12,13 +12,13 @@ spec:
             default: "docker.io"
           - name: purge
             default: "false"
-          - name: image_version
+          - name: image-version
             default: nightly
           - name: repository
             default: pingcap
-          - name: storage_class
+          - name: storage-class
             default: standard
-          - name: run_time
+          - name: run-time
             default: "5h"
           - name: nemesis
             default: "random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler"
@@ -28,11 +28,11 @@ spec:
             default: loki
           - name: loki-password
             default: admin
-          - name: tidb_config
+          - name: tidb-config
             default: ""
-          - name: tikv_config
+          - name: tikv-config
             default: ""
-          - name: pd_config
+          - name: pd-config
             default: ""
           - name: tikv-replicas
             default: "3"
@@ -58,13 +58,13 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -run-time={{inputs.parameters.run_time}} \
-            -image-version={{inputs.parameters.image_version}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -run-time={{inputs.parameters.run-time}} \
+            -image-version={{inputs.parameters.image-version}} \
             -purge={{inputs.parameters.purge}} \
-            -tidb-config={{inputs.parameters.tidb_config}} \
-            -tikv-config={{inputs.parameters.tikv_config}} \
-            -pd-config={{inputs.parameters.pd_config}} \
+            -tidb-config={{inputs.parameters.tidb-config}} \
+            -tikv-config={{inputs.parameters.tikv-config}} \
+            -pd-config={{inputs.parameters.pd-config}} \
             -nemesis={{inputs.parameters.nemesis}} \
             -tikv-replicas={{inputs.parameters.tikv-replicas}} \
             -loki-addr={{inputs.parameters.loki-addr}} \

--- a/argo/template/sc_bank2.yaml
+++ b/argo/template/sc_bank2.yaml
@@ -14,11 +14,11 @@ spec:
             default: "false"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: storage_class
+          - name: storage-class
             default: standard
-          - name: run_time
+          - name: run-time
             default: "5h"
           - name: nemesis
             default: "random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler"
@@ -28,11 +28,11 @@ spec:
             default: loki
           - name: loki-password
             default: admin
-          - name: tidb_config
+          - name: tidb-config
             default: ""
-          - name: tikv_config
+          - name: tikv-config
             default: ""
-          - name: pd_config
+          - name: pd-config
             default: ""
           - name: tikv-replicas
             default: "3"
@@ -58,13 +58,13 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -run-time={{inputs.parameters.run_time}} \
-            -image-version={{inputs.parameters.image_version}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -run-time={{inputs.parameters.run-time}} \
+            -image-version={{inputs.parameters.image-version}} \
             -purge={{inputs.parameters.purge}} \
-            -tidb-config={{inputs.parameters.tidb_config}} \
-            -tikv-config={{inputs.parameters.tikv_config}} \
-            -pd-config={{inputs.parameters.pd_config}} \
+            -tidb-config={{inputs.parameters.tidb-config}} \
+            -tikv-config={{inputs.parameters.tikv-config}} \
+            -pd-config={{inputs.parameters.pd-config}} \
             -nemesis={{inputs.parameters.nemesis}} \
             -tikv-replicas={{inputs.parameters.tikv-replicas}} \
             -loki-addr={{inputs.parameters.loki-addr}} \

--- a/argo/template/sqllogic.yaml
+++ b/argo/template/sqllogic.yaml
@@ -14,11 +14,11 @@ spec:
             default: "false"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: storage_class
+          - name: storage-class
             default: standard
-          - name: run_time
+          - name: run-time
             default: "8h"
           - name: loki-addr
             default: http://gateway.loki.svc
@@ -48,10 +48,10 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
             -purge={{inputs.parameters.purge}} \
-            -run-time={{inputs.parameters.run_time}} \
+            -run-time={{inputs.parameters.run-time}} \
             -p=https://codeload.github.com/mahjonp/sqllogictest/zip/tipocket \
             -d=sqllogictest-tipocket \
             -loki-addr={{inputs.parameters.loki-addr}} \

--- a/argo/template/tiflash-abtest.yaml
+++ b/argo/template/tiflash-abtest.yaml
@@ -12,35 +12,35 @@ spec:
             default: "docker.io"
           - name: purge
             default: "true"
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: abtest_version
+          - name: abtest_image-version
             value: latest
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: ""
           - name: client
             default: "2"
-          - name: run_time
+          - name: run-time
             default: "48h"
-          - name: tidb_config
+          - name: tidb-config
             default: ""
-          - name: tikv_config
+          - name: tikv-config
             default: ""
-          - name: pd_config
+          - name: pd-config
             default: ""
-          - name: abtest_tidb_config
+          - name: abtest_tidb-config
             default: ""
-          - name: abtest_tikv_config
+          - name: abtest_tikv-config
             default: ""
-          - name: abtest_pd_config
+          - name: abtest_pd-config
             default: ""
-          - name: abtest_general_log
+          - name: abtest_general-log
             default: "true"
-          - name: tiflash_image
+          - name: tiflash-image
             default: ""
-          - name: tiflash_replicas
+          - name: tiflash-replicas
             default: 2
           - name: loki-addr
             default: http://gateway.loki.svc
@@ -67,22 +67,22 @@ spec:
             /bin/tiflash-abtest \
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
-            -abtest.image-version={{inputs.parameters.abtest_version}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
+            -abtest.image-version={{inputs.parameters.abtest_image-version}} \
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
             -client={{inputs.parameters.client}} \
-            -run-time={{inputs.parameters.run_time}} \
-            -tidb-config={{inputs.parameters.tidb_config}} \
-            -tikv-config={{inputs.parameters.tikv_config}} \
-            -pd-config={{inputs.parameters.pd_config}} \
-            -abtest.tidb-config={{inputs.parameters.abtest_tidb_config}} \
-            -abtest.tikv-config={{inputs.parameters.abtest_tikv_config}} \
-            -abtest.pd-config={{inputs.parameters.abtest_pd_config}} \
-            -abtest.general-log={{inputs.parameters.abtest_general_log}} \
-            -tiflash-replicas={{inputs.parameters.tiflash_replicas}} \
-            -tiflash-image={{inputs.parameters.tiflash_image}} \
+            -run-time={{inputs.parameters.run-time}} \
+            -tidb-config={{inputs.parameters.tidb-config}} \
+            -tikv-config={{inputs.parameters.tikv-config}} \
+            -pd-config={{inputs.parameters.pd-config}} \
+            -abtest.tidb-config={{inputs.parameters.abtest_tidb-config}} \
+            -abtest.tikv-config={{inputs.parameters.abtest_tikv-config}} \
+            -abtest.pd-config={{inputs.parameters.abtest_pd-config}} \
+            -abtest.general-log={{inputs.parameters.abtest_general-log}} \
+            -tiflash-replicas={{inputs.parameters.tiflash-replicas}} \
+            -tiflash-image={{inputs.parameters.tiflash-image}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/tiflash-cdc.yaml
+++ b/argo/template/tiflash-cdc.yaml
@@ -12,41 +12,41 @@ spec:
             default: "docker.io"
           - name: purge
             default: "true"
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: tidb_image
+          - name: tidb-image
             default: ""
-          - name: tikv_image
+          - name: tikv-image
             default: ""
-          - name: pd_image
+          - name: pd-image
             default: ""
-          - name: abtest_version
+          - name: abtest_image-version
             value: latest
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: ""
           - name: client
             default: "2"
-          - name: run_time
+          - name: run-time
             default: "48h"
-          - name: tidb_config
+          - name: tidb-config
             default: ""
-          - name: tikv_config
+          - name: tikv-config
             default: ""
-          - name: pd_config
+          - name: pd-config
             default: ""
-          - name: abtest_tidb_config
+          - name: abtest_tidb-config
             default: ""
-          - name: abtest_tikv_config
+          - name: abtest_tikv-config
             default: ""
-          - name: abtest_pd_config
+          - name: abtest_pd-config
             default: ""
-          - name: abtest_general_log
+          - name: abtest_general-log
             default: "true"
-          - name: tiflash_image
+          - name: tiflash-image
             default: ""
-          - name: tiflash_replicas
+          - name: tiflash-replicas
             default: 2
           - name: cdc_hub
             default: docker.io
@@ -79,25 +79,25 @@ spec:
             /bin/tiflash-cdc \
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
-            -tidb-image={{inputs.parameters.tidb_image}} \
-            -tikv-image={{inputs.parameters.tikv_image}} \
-            -pd-image={{inputs.parameters.pd_image}} \
-            -abtest.image-version={{inputs.parameters.abtest_version}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
+            -tidb-image={{inputs.parameters.tidb-image}} \
+            -tikv-image={{inputs.parameters.tikv-image}} \
+            -pd-image={{inputs.parameters.pd-image}} \
+            -abtest.image-version={{inputs.parameters.abtest_image-version}} \
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
             -client={{inputs.parameters.client}} \
-            -run-time={{inputs.parameters.run_time}} \
-            -tidb-config={{inputs.parameters.tidb_config}} \
-            -tikv-config={{inputs.parameters.tikv_config}} \
-            -pd-config={{inputs.parameters.pd_config}} \
-            -abtest.tidb-config={{inputs.parameters.abtest_tidb_config}} \
-            -abtest.tikv-config={{inputs.parameters.abtest_tikv_config}} \
-            -abtest.pd-config={{inputs.parameters.abtest_pd_config}} \
-            -abtest.general-log={{inputs.parameters.abtest_general_log}} \
-            -tiflash-replicas={{inputs.parameters.tiflash_replicas}} \
-            -tiflash-image={{inputs.parameters.tiflash_image}} \
+            -run-time={{inputs.parameters.run-time}} \
+            -tidb-config={{inputs.parameters.tidb-config}} \
+            -tikv-config={{inputs.parameters.tikv-config}} \
+            -pd-config={{inputs.parameters.pd-config}} \
+            -abtest.tidb-config={{inputs.parameters.abtest_tidb-config}} \
+            -abtest.tikv-config={{inputs.parameters.abtest_tikv-config}} \
+            -abtest.pd-config={{inputs.parameters.abtest_pd-config}} \
+            -abtest.general-log={{inputs.parameters.abtest_general-log}} \
+            -tiflash-replicas={{inputs.parameters.tiflash-replicas}} \
+            -tiflash-image={{inputs.parameters.tiflash-image}} \
             -cdc.hub={{inputs.parameters.cdc_hub}} \
             -cdc.repository={{inputs.parameters.cdc_repository}} \
             -cdc.version={{inputs.parameters.cdc_version}} \

--- a/argo/template/tiflash.yaml
+++ b/argo/template/tiflash.yaml
@@ -14,17 +14,17 @@ spec:
             default: "false"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: ""
-          - name: tiflash_image
+          - name: tiflash-image
             default: ""
-          - name: tiflash_replicas
+          - name: tiflash-replicas
             default: 2
-          - name: run_time
+          - name: run-time
             default: "48h"
           - name: loki-addr
             default: http://gateway.loki.svc
@@ -52,13 +52,13 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
-            -run-time={{inputs.parameters.run_time}} \
-            -tiflash-replicas={{inputs.parameters.tiflash_replicas}} \
-            -tiflash-image={{inputs.parameters.tiflash_image}} \
+            -run-time={{inputs.parameters.run-time}} \
+            -tiflash-replicas={{inputs.parameters.tiflash-replicas}} \
+            -tiflash-image={{inputs.parameters.tiflash-image}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/tpcc.yaml
+++ b/argo/template/tpcc.yaml
@@ -14,13 +14,13 @@ spec:
             default: "false"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: client
             default: "100"
-          - name: request_count
+          - name: request-count
             default: "1000000"
           - name: round
             default: "10"
@@ -52,13 +52,13 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
             -purge={{inputs.parameters.purge}} \
             -client={{inputs.parameters.client}} \
             -nemesis={{inputs.parameters.nemesis}} \
             -round={{inputs.parameters.round}} \
-            -request-count={{inputs.parameters.request_count}} \
+            -request-count={{inputs.parameters.request-count}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/txn-rand-pessimistic.yaml
+++ b/argo/template/txn-rand-pessimistic.yaml
@@ -14,13 +14,13 @@ spec:
             default: "false"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: ""
-          - name: run_time
+          - name: run-time
             default: "4h"
           - name: loki-addr
             default: http://gateway.loki.svc
@@ -48,11 +48,11 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
             -purge={{inputs.parameters.purge}} \
             -nemesis={{inputs.parameters.nemesis}} \
-            -run-time={{inputs.parameters.run_time}} \
+            -run-time={{inputs.parameters.run-time}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}}

--- a/argo/template/vbank.yaml
+++ b/argo/template/vbank.yaml
@@ -14,15 +14,15 @@ spec:
             default: "false"
           - name: repository
             default: pingcap
-          - name: image_version
+          - name: image-version
             default: nightly
-          - name: storage_class
+          - name: storage-class
             default: standard
           - name: nemesis
             default: "random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler"
           - name: client
             default: "5"
-          - name: request_count
+          - name: request-count
             default: "10000"
           - name: round
             default: "100"
@@ -32,11 +32,11 @@ spec:
             default: loki
           - name: loki-password
             default: admin
-          - name: tidb_config
+          - name: tidb-config
             default: ""
-          - name: tikv_config
+          - name: tikv-config
             default: ""
-          - name: pd_config
+          - name: pd-config
             default: ""
           - name: tikv-replicas
             default: "3"
@@ -64,17 +64,17 @@ spec:
             -namespace={{inputs.parameters.ns}} \
             -hub={{inputs.parameters.hub}} \
             -repository={{inputs.parameters.repository}} \
-            -storage-class={{inputs.parameters.storage_class}} \
-            -image-version={{inputs.parameters.image_version}} \
-            -tidb-config={{inputs.parameters.tidb_config}} \
-            -tikv-config={{inputs.parameters.tikv_config}} \
-            -pd-config={{inputs.parameters.pd_config}} \
+            -storage-class={{inputs.parameters.storage-class}} \
+            -image-version={{inputs.parameters.image-version}} \
+            -tidb-config={{inputs.parameters.tidb-config}} \
+            -tikv-config={{inputs.parameters.tikv-config}} \
+            -pd-config={{inputs.parameters.pd-config}} \
             -purge={{inputs.parameters.purge}} \
             -client={{inputs.parameters.client}} \
             -tikv-replicas={{inputs.parameters.tikv-replicas}} \
             -nemesis={{inputs.parameters.nemesis}} \
             -round={{inputs.parameters.round}} \
-            -request-count={{inputs.parameters.request_count}} \
+            -request-count={{inputs.parameters.request-count}} \
             -loki-addr={{inputs.parameters.loki-addr}} \
             -loki-username={{inputs.parameters.loki-username}} \
             -loki-password={{inputs.parameters.loki-password}}

--- a/argo/workflow/abtest-chunk-rpc.yaml
+++ b/argo/workflow/abtest-chunk-rpc.yaml
@@ -9,31 +9,31 @@ spec:
         value: tipocket-ab-enable-thunk
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: release-4.0-nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
-      - name: abtest_version
+      - name: abtest_image-version
         value: release-4.0-nightly
       - name: nemesis
         value: ""
       - name: client
         value: "2"
-      - name: tidb_config
+      - name: tidb-config
         value: "/config/tidb/enable-chunk-rpc.toml"
-      - name: tikv_config
+      - name: tikv-config
         value: ""
-      - name: pd_config
+      - name: pd-config
         value: ""
-      - name: abtest_tidb_config
+      - name: abtest_tidb-config
         value: "/config/tidb/enable-chunk-rpc-false.toml"
-      - name: abtest_tikv_config
+      - name: abtest_tikv-config
         value: ""
-      - name: abtest_pd_config
+      - name: abtest_pd-config
         value: ""
       - name: abtest_concurrency
         value: "3"
-      - name: abtest_general_log
+      - name: abtest_general-log
         value: "true"
       - name: loki-addr
         value: "http://gateway.loki.svc"
@@ -54,32 +54,32 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
-                - name: abtest_version
-                  value: "{{workflow.parameters.abtest_version}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
+                - name: abtest_image-version
+                  value: "{{workflow.parameters.abtest_image-version}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
                 - name: client
                   value: "{{workflow.parameters.client}}"
-                - name: tidb_config
-                  value: "{{workflow.parameters.tidb_config}}"
-                - name: tikv_config
-                  value: "{{workflow.parameters.tikv_config}}"
-                - name: pd_config
-                  value: "{{workflow.parameters.pd_config}}"
-                - name: abtest_tidb_config
-                  value: "{{workflow.parameters.abtest_tidb_config}}"
-                - name: abtest_tikv_config
-                  value: "{{workflow.parameters.abtest_tikv_config}}"
-                - name: abtest_pd_config
-                  value: "{{workflow.parameters.abtest_pd_config}}"
+                - name: tidb-config
+                  value: "{{workflow.parameters.tidb-config}}"
+                - name: tikv-config
+                  value: "{{workflow.parameters.tikv-config}}"
+                - name: pd-config
+                  value: "{{workflow.parameters.pd-config}}"
+                - name: abtest_tidb-config
+                  value: "{{workflow.parameters.abtest_tidb-config}}"
+                - name: abtest_tikv-config
+                  value: "{{workflow.parameters.abtest_tikv-config}}"
+                - name: abtest_pd-config
+                  value: "{{workflow.parameters.abtest_pd-config}}"
                 - name: abtest_concurrency
                   value: "{{workflow.parameters.abtest_concurrency}}"
-                - name: abtest_general_log
-                  value: "{{workflow.parameters.abtest_general_log}}"
+                - name: abtest_general-log
+                  value: "{{workflow.parameters.abtest_general-log}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username

--- a/argo/workflow/abtest-plan-cache.yaml
+++ b/argo/workflow/abtest-plan-cache.yaml
@@ -9,31 +9,31 @@ spec:
         value: tipocket-ab-plan-cache
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: release-4.0-nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
-      - name: abtest_version
+      - name: abtest_image-version
         value: release-4.0-nightly
       - name: nemesis
         value: ""
       - name: client
         value: "2"
-      - name: tidb_config
+      - name: tidb-config
         value: "/config/tidb/prepared-plan-cache.toml"
-      - name: tikv_config
+      - name: tikv-config
         value: ""
-      - name: pd_config
+      - name: pd-config
         value: ""
-      - name: abtest_tidb_config
+      - name: abtest_tidb-config
         value: "/config/tidb/prepared-plan-cache-false.toml"
-      - name: abtest_tikv_config
+      - name: abtest_tikv-config
         value: ""
-      - name: abtest_pd_config
+      - name: abtest_pd-config
         value: ""
       - name: abtest_concurrency
         value: "3"
-      - name: abtest_general_log
+      - name: abtest_general-log
         value: "true"
       - name: loki-addr
         value: "http://gateway.loki.svc"
@@ -54,32 +54,32 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
-                - name: abtest_version
-                  value: "{{workflow.parameters.abtest_version}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
+                - name: abtest_image-version
+                  value: "{{workflow.parameters.abtest_image-version}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
                 - name: client
                   value: "{{workflow.parameters.client}}"
-                - name: tidb_config
-                  value: "{{workflow.parameters.tidb_config}}"
-                - name: tikv_config
-                  value: "{{workflow.parameters.tikv_config}}"
-                - name: pd_config
-                  value: "{{workflow.parameters.pd_config}}"
-                - name: abtest_tidb_config
-                  value: "{{workflow.parameters.abtest_tidb_config}}"
-                - name: abtest_tikv_config
-                  value: "{{workflow.parameters.abtest_tikv_config}}"
-                - name: abtest_pd_config
-                  value: "{{workflow.parameters.abtest_pd_config}}"
+                - name: tidb-config
+                  value: "{{workflow.parameters.tidb-config}}"
+                - name: tikv-config
+                  value: "{{workflow.parameters.tikv-config}}"
+                - name: pd-config
+                  value: "{{workflow.parameters.pd-config}}"
+                - name: abtest_tidb-config
+                  value: "{{workflow.parameters.abtest_tidb-config}}"
+                - name: abtest_tikv-config
+                  value: "{{workflow.parameters.abtest_tikv-config}}"
+                - name: abtest_pd-config
+                  value: "{{workflow.parameters.abtest_pd-config}}"
                 - name: abtest_concurrency
                   value: "{{workflow.parameters.abtest_concurrency}}"
-                - name: abtest_general_log
-                  value: "{{workflow.parameters.abtest_general_log}}"
+                - name: abtest_general-log
+                  value: "{{workflow.parameters.abtest_general-log}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username

--- a/argo/workflow/abtest-tmp-storage.yaml
+++ b/argo/workflow/abtest-tmp-storage.yaml
@@ -9,31 +9,31 @@ spec:
         value: tipocket-ab-tmp-storage
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: release-4.0-nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
-      - name: abtest_version
+      - name: abtest_image-version
         value: release-4.0-nightly
       - name: nemesis
         value: ""
       - name: client
         value: "2"
-      - name: tidb_config
+      - name: tidb-config
         value: "/config/tidb/oom-use-tmp-storage.toml"
-      - name: tikv_config
+      - name: tikv-config
         value: ""
-      - name: pd_config
+      - name: pd-config
         value: ""
-      - name: abtest_tidb_config
+      - name: abtest_tidb-config
         value: "/config/tidb/oom-use-tmp-storage-false.toml"
-      - name: abtest_tikv_config
+      - name: abtest_tikv-config
         value: ""
-      - name: abtest_pd_config
+      - name: abtest_pd-config
         value: ""
       - name: abtest_concurrency
         value: "3"
-      - name: abtest_general_log
+      - name: abtest_general-log
         value: "true"
       - name: loki-addr
         value: "http://gateway.loki.svc"
@@ -54,32 +54,32 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
-                - name: abtest_version
-                  value: "{{workflow.parameters.abtest_version}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
+                - name: abtest_image-version
+                  value: "{{workflow.parameters.abtest_image-version}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
                 - name: client
                   value: "{{workflow.parameters.client}}"
-                - name: tidb_config
-                  value: "{{workflow.parameters.tidb_config}}"
-                - name: tikv_config
-                  value: "{{workflow.parameters.tikv_config}}"
-                - name: pd_config
-                  value: "{{workflow.parameters.pd_config}}"
-                - name: abtest_tidb_config
-                  value: "{{workflow.parameters.abtest_tidb_config}}"
-                - name: abtest_tikv_config
-                  value: "{{workflow.parameters.abtest_tikv_config}}"
-                - name: abtest_pd_config
-                  value: "{{workflow.parameters.abtest_pd_config}}"
+                - name: tidb-config
+                  value: "{{workflow.parameters.tidb-config}}"
+                - name: tikv-config
+                  value: "{{workflow.parameters.tikv-config}}"
+                - name: pd-config
+                  value: "{{workflow.parameters.pd-config}}"
+                - name: abtest_tidb-config
+                  value: "{{workflow.parameters.abtest_tidb-config}}"
+                - name: abtest_tikv-config
+                  value: "{{workflow.parameters.abtest_tikv-config}}"
+                - name: abtest_pd-config
+                  value: "{{workflow.parameters.abtest_pd-config}}"
                 - name: abtest_concurrency
                   value: "{{workflow.parameters.abtest_concurrency}}"
-                - name: abtest_general_log
-                  value: "{{workflow.parameters.abtest_general_log}}"
+                - name: abtest_general-log
+                  value: "{{workflow.parameters.abtest_general-log}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username

--- a/argo/workflow/abtest.yaml
+++ b/argo/workflow/abtest.yaml
@@ -9,31 +9,31 @@ spec:
         value: tipocket-abtest
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: release-4.0-nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
-      - name: abtest_version
+      - name: abtest_image-version
         value: latest
       - name: nemesis
         value: ""
       - name: client
         value: "2"
-      - name: tidb_config
+      - name: tidb-config
         value: ""
-      - name: tikv_config
+      - name: tikv-config
         value: ""
-      - name: pd_config
+      - name: pd-config
         value: ""
-      - name: abtest_tidb_config
+      - name: abtest_tidb-config
         value: ""
-      - name: abtest_tikv_config
+      - name: abtest_tikv-config
         value: ""
-      - name: abtest_pd_config
+      - name: abtest_pd-config
         value: ""
       - name: abtest_concurrency
         value: "3"
-      - name: abtest_general_log
+      - name: abtest_general-log
         value: "true"
       - name: loki-addr
         value: "http://gateway.loki.svc"
@@ -54,32 +54,32 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
-                - name: abtest_version
-                  value: "{{workflow.parameters.abtest_version}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
+                - name: abtest_image-version
+                  value: "{{workflow.parameters.abtest_image-version}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
                 - name: client
                   value: "{{workflow.parameters.client}}"
-                - name: tidb_config
-                  value: "{{workflow.parameters.tidb_config}}"
-                - name: tikv_config
-                  value: "{{workflow.parameters.tikv_config}}"
-                - name: pd_config
-                  value: "{{workflow.parameters.pd_config}}"
-                - name: abtest_tidb_config
-                  value: "{{workflow.parameters.abtest_tidb_config}}"
-                - name: abtest_tikv_config
-                  value: "{{workflow.parameters.abtest_tikv_config}}"
-                - name: abtest_pd_config
-                  value: "{{workflow.parameters.abtest_pd_config}}"
+                - name: tidb-config
+                  value: "{{workflow.parameters.tidb-config}}"
+                - name: tikv-config
+                  value: "{{workflow.parameters.tikv-config}}"
+                - name: pd-config
+                  value: "{{workflow.parameters.pd-config}}"
+                - name: abtest_tidb-config
+                  value: "{{workflow.parameters.abtest_tidb-config}}"
+                - name: abtest_tikv-config
+                  value: "{{workflow.parameters.abtest_tikv-config}}"
+                - name: abtest_pd-config
+                  value: "{{workflow.parameters.abtest_pd-config}}"
                 - name: abtest_concurrency
                   value: "{{workflow.parameters.abtest_concurrency}}"
-                - name: abtest_general_log
-                  value: "{{workflow.parameters.abtest_general_log}}"
+                - name: abtest_general-log
+                  value: "{{workflow.parameters.abtest_general-log}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username

--- a/argo/workflow/bank-follower-read.yaml
+++ b/argo/workflow/bank-follower-read.yaml
@@ -9,11 +9,11 @@ spec:
         value: tipocket-bank-replica-read
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
-      - name: run_time
+      - name: run-time
         value: "6h"
       - name: loki-addr
         value: "http://gateway.loki.svc"
@@ -38,12 +38,12 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
-                - name: run_time
-                  value: "{{workflow.parameters.run_time}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
+                - name: run-time
+                  value: "{{workflow.parameters.run-time}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username

--- a/argo/workflow/bank-iochaos.yaml
+++ b/argo/workflow/bank-iochaos.yaml
@@ -9,15 +9,15 @@ spec:
         value: tipocket-bank-iochaos
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: release-4.0-nightly
-      - name: storage_class
+      - name: storage-class
         value: local-scsi
       - name: nemesis
         value: "delay_tikv"
       - name: client
         value: "5"
-      - name: request_count
+      - name: request-count
         value: "10000"
       - name: round
         value: "100"
@@ -40,16 +40,16 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
                 - name: client
                   value: "{{workflow.parameters.client}}"
-                - name: request_count
-                  value: "{{workflow.parameters.request_count}}"
+                - name: request-count
+                  value: "{{workflow.parameters.request-count}}"
                 - name: round
                   value: "{{workflow.parameters.round}}"
                 - name: loki-addr

--- a/argo/workflow/bank2-follower-read.yaml
+++ b/argo/workflow/bank2-follower-read.yaml
@@ -9,11 +9,11 @@ spec:
         value: tipocket-bank2-replica-read
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
-      - name: run_time
+      - name: run-time
         value: "6h"
       - name: loki-addr
         value: "http://gateway.loki.svc"
@@ -38,12 +38,12 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
-                - name: run_time
-                  value: "{{workflow.parameters.run_time}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
+                - name: run-time
+                  value: "{{workflow.parameters.run-time}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username

--- a/argo/workflow/binlog.yaml
+++ b/argo/workflow/binlog.yaml
@@ -9,19 +9,19 @@ spec:
         value: tipocket-binlog
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: release-4.0-nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
       - name: nemesis
         value: ""
-      - name: run_time
+      - name: run-time
         value: "60m"
-      - name: relay_log
+      - name: relay-log
         value: "true"
-      - name: abtest_general_log
+      - name: abtest_general-log
         value: "true"
-      - name: binlog_sync_timeout
+      - name: binlog_sync-timeout
         value: "1h"
       - name: abtest_concurrency
         value: "3"
@@ -44,20 +44,20 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
-                - name: run_time
-                  value: "{{workflow.parameters.run_time}}"
-                - name: relay_log
-                  value: "{{workflow.parameters.relay_log}}"
-                - name: abtest_general_log
-                  value: "{{workflow.parameters.abtest_general_log}}"
-                - name: binlog_sync_timeout
-                  value: "{{workflow.parameters.binlog_sync_timeout}}"
+                - name: run-time
+                  value: "{{workflow.parameters.run-time}}"
+                - name: relay-log
+                  value: "{{workflow.parameters.relay-log}}"
+                - name: abtest_general-log
+                  value: "{{workflow.parameters.abtest_general-log}}"
+                - name: binlog_sync-timeout
+                  value: "{{workflow.parameters.binlog_sync-timeout}}"
                 - name: abtest_concurrency
                   value: "{{workflow.parameters.abtest_concurrency}}"
                 - name: loki-addr

--- a/argo/workflow/block-writer.yaml
+++ b/argo/workflow/block-writer.yaml
@@ -9,13 +9,13 @@ spec:
         value: tipocket-block-writer
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: release-4.0-nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
       - name: nemesis
         value: ""
-      - name: run_time
+      - name: run-time
         value: "60m"
       - name: loki-addr
         value: "http://gateway.loki.svc"
@@ -36,14 +36,14 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
-                - name: run_time
-                  value: "{{workflow.parameters.run_time}}"
+                - name: run-time
+                  value: "{{workflow.parameters.run-time}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username

--- a/argo/workflow/cdc.yaml
+++ b/argo/workflow/cdc.yaml
@@ -13,21 +13,21 @@ spec:
         value: "docker.io"
       - name: repository
         value: "pingcap"
-      - name: image_version
+      - name: image-version
         value: nightly
-      - name: tidb_image
+      - name: tidb-image
         value: ""
-      - name: tikv_image
+      - name: tikv-image
         value: ""
-      - name: pd_image
+      - name: pd-image
         value: ""
-      - name: storage_class
+      - name: storage-class
         value: gp2
       - name: nemesis
         value: ""
-      - name: run_time
+      - name: run-time
         value: "12h"
-      - name: tikv_config
+      - name: tikv-config
         value: ""
       - name: cdc_hub
         value: "docker.io"
@@ -35,13 +35,13 @@ spec:
         value: "pingcap"
       - name: cdc_version
         value: "nightly"
-      - name: cdc_enable_kafka
+      - name: cdc_enable-kafka
         value: "false"
-      - name: cdc_kafka_consumer_image
+      - name: cdc_kafka-consumer-image
         value: "docker.io/pingcap/ticdc-kafka:nightly"
-      - name: abtest_general_log
+      - name: abtest_general-log
         value: "true"
-      - name: binlog_sync_timeout
+      - name: binlog_sync-timeout
         value: "1h"
       - name: abtest_concurrency
         value: "3"
@@ -68,36 +68,36 @@ spec:
                   value: "{{workflow.parameters.hub}}"
                 - name: repository
                   value: "{{workflow.parameters.repository}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: tidb_image
-                  value: "{{workflow.parameters.tidb_image}}"
-                - name: tikv_image
-                  value: "{{workflow.parameters.tikv_image}}"
-                - name: pd_image
-                  value: "{{workflow.parameters.pd_image}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: tidb-image
+                  value: "{{workflow.parameters.tidb-image}}"
+                - name: tikv-image
+                  value: "{{workflow.parameters.tikv-image}}"
+                - name: pd-image
+                  value: "{{workflow.parameters.pd-image}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
-                - name: run_time
-                  value: "{{workflow.parameters.run_time}}"
-                - name: tikv_config
-                  value: "{{workflow.parameters.tikv_config}}"
+                - name: run-time
+                  value: "{{workflow.parameters.run-time}}"
+                - name: tikv-config
+                  value: "{{workflow.parameters.tikv-config}}"
                 - name: cdc_hub
                   value: "{{workflow.parameters.cdc_hub}}"
                 - name: cdc_repository
                   value: "{{workflow.parameters.cdc_repository}}"
                 - name: cdc_version
                   value: "{{workflow.parameters.cdc_version}}"
-                - name: cdc_enable_kafka
-                  value: "{{workflow.parameters.cdc_enable_kafka}}"
-                - name: cdc_kafka_consumer_image
-                  value: "{{workflow.parameters.cdc_kafka_consumer_image}}"
-                - name: abtest_general_log
-                  value: "{{workflow.parameters.abtest_general_log}}"
-                - name: binlog_sync_timeout
-                  value: "{{workflow.parameters.binlog_sync_timeout}}"
+                - name: cdc_enable-kafka
+                  value: "{{workflow.parameters.cdc_enable-kafka}}"
+                - name: cdc_kafka-consumer-image
+                  value: "{{workflow.parameters.cdc_kafka-consumer-image}}"
+                - name: abtest_general-log
+                  value: "{{workflow.parameters.abtest_general-log}}"
+                - name: binlog_sync-timeout
+                  value: "{{workflow.parameters.binlog_sync-timeout}}"
                 - name: abtest_concurrency
                   value: "{{workflow.parameters.abtest_concurrency}}"
                 - name: loki-addr

--- a/argo/workflow/follower-read.yaml
+++ b/argo/workflow/follower-read.yaml
@@ -11,13 +11,13 @@ spec:
         value: "true"
       - name: repository
         value: pingcap
-      - name: image_version
+      - name: image-version
         value: nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
       - name: nemesis
         value: ""
-      - name: run_time
+      - name: run-time
         value: "6h"
       - name: loki-username
         value: loki
@@ -40,14 +40,14 @@ spec:
                   value: "{{workflow.parameters.purge}}"
                 - name: repository
                   value: "{{workflow.parameters.repository}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
-                - name: run_time
-                  value: "{{workflow.parameters.run_time}}"
+                - name: run-time
+                  value: "{{workflow.parameters.run-time}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username

--- a/argo/workflow/rawkv-linearizability.yaml
+++ b/argo/workflow/rawkv-linearizability.yaml
@@ -9,15 +9,15 @@ spec:
         value: tipocket-rawkv-linearizability
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: release-4.0-nightly
-      - name: storage_class
+      - name: storage-class
         value: pd-ssd
       - name: nemesis
         value: "partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler"
       - name: client
         value: "5"
-      - name: request_count
+      - name: request-count
         value: "20000"
       - name: round
         value: "100"
@@ -40,16 +40,16 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
                 - name: client
                   value: "{{workflow.parameters.client}}"
-                - name: request_count
-                  value: "{{workflow.parameters.request_count}}"
+                - name: request-count
+                  value: "{{workflow.parameters.request-count}}"
                 - name: round
                   value: "{{workflow.parameters.round}}"
                 - name: loki-addr

--- a/argo/workflow/read-stress-unify-all.yaml
+++ b/argo/workflow/read-stress-unify-all.yaml
@@ -11,15 +11,15 @@ spec:
         value: "true"
       - name: repository
         value: pingcap
-      - name: image_version
+      - name: image-version
         value: nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
       - name: nemesis
         value: ""
-      - name: run_time
+      - name: run-time
         value: "6h"
-      - name: tikv_config
+      - name: tikv-config
         value: "/config/tikv/unify-all-read-pools.toml"
       - name: loki-addr
         value: ""
@@ -48,22 +48,22 @@ spec:
                   value: "{{workflow.parameters.purge}}"
                 - name: repository
                   value: "{{workflow.parameters.repository}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
-                - name: run_time
-                  value: "{{workflow.parameters.run_time}}"
+                - name: run-time
+                  value: "{{workflow.parameters.run-time}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username
                   value: "{{workflow.parameters.loki-username}}"
                 - name: loki-password
                   value: "{{workflow.parameters.loki-password}}"
-                - name: tikv_config
-                  value: "{{workflow.parameters.tikv_config}}"
+                - name: tikv-config
+                  value: "{{workflow.parameters.tikv-config}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username

--- a/argo/workflow/read-stress-with-replica-read.yaml
+++ b/argo/workflow/read-stress-with-replica-read.yaml
@@ -11,13 +11,13 @@ spec:
         value: "true"
       - name: repository
         value: pingcap
-      - name: image_version
+      - name: image-version
         value: nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
       - name: nemesis
         value: ""
-      - name: run_time
+      - name: run-time
         value: "6h"
       - name: loki-addr
         value: "http://gateway.loki.svc"
@@ -42,14 +42,14 @@ spec:
                   value: "{{workflow.parameters.purge}}"
                 - name: repository
                   value: "{{workflow.parameters.repository}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
-                - name: run_time
-                  value: "{{workflow.parameters.run_time}}"
+                - name: run-time
+                  value: "{{workflow.parameters.run-time}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username

--- a/argo/workflow/region-available.yaml
+++ b/argo/workflow/region-available.yaml
@@ -9,13 +9,13 @@ spec:
         value: tipocket-region-available
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: nightly
-      - name: storage_class
+      - name: storage-class
         value: local-storage
       - name: nemesis
         value: ""
-      - name: run_time
+      - name: run-time
         value: "4h"
       - name: loki-addr
         value: "http://loki.loki.svc"
@@ -36,14 +36,14 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
-                - name: run_time
-                  value: "{{workflow.parameters.run_time}}"
+                - name: run-time
+                  value: "{{workflow.parameters.run-time}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username

--- a/argo/workflow/sqllogic.yaml
+++ b/argo/workflow/sqllogic.yaml
@@ -9,11 +9,11 @@ spec:
         value: tipocket-sqllogic
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: release-4.0-nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
-      - name: run_time
+      - name: run-time
         value: "8h"
       - name: loki-addr
         value: "http://gateway.loki.svc"
@@ -34,12 +34,12 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
-                - name: run_time
-                  value: "{{workflow.parameters.run_time}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
+                - name: run-time
+                  value: "{{workflow.parameters.run-time}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username

--- a/argo/workflow/tiflash-abtest.yaml
+++ b/argo/workflow/tiflash-abtest.yaml
@@ -9,33 +9,33 @@ spec:
         value: tipocket-tiflash-abtest
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: release-4.0-nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
-      - name: abtest_version
+      - name: abtest_image-version
         value: release-4.0-nightly
       - name: nemesis
         value: ""
       - name: client
         value: "2"
-      - name: tidb_config
+      - name: tidb-config
         value: ""
-      - name: tikv_config
+      - name: tikv-config
         value: ""
-      - name: pd_config
+      - name: pd-config
         value: ""
-      - name: abtest_tidb_config
+      - name: abtest_tidb-config
         value: ""
-      - name: abtest_tikv_config
+      - name: abtest_tikv-config
         value: ""
-      - name: abtest_pd_config
+      - name: abtest_pd-config
         value: ""
-      - name: abtest_general_log
+      - name: abtest_general-log
         value: "true"
-      - name: tiflash_image
+      - name: tiflash-image
         value: "v4.0.0-rc"
-      - name: tiflash_replicas
+      - name: tiflash-replicas
         value: 2
       - name: loki-addr
         value: "http://gateway.loki.svc"
@@ -56,34 +56,34 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
-                - name: abtest_version
-                  value: "{{workflow.parameters.abtest_version}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
+                - name: abtest_image-version
+                  value: "{{workflow.parameters.abtest_image-version}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
                 - name: client
                   value: "{{workflow.parameters.client}}"
-                - name: tidb_config
-                  value: "{{workflow.parameters.tidb_config}}"
-                - name: tikv_config
-                  value: "{{workflow.parameters.tikv_config}}"
-                - name: pd_config
-                  value: "{{workflow.parameters.pd_config}}"
-                - name: abtest_tidb_config
-                  value: "{{workflow.parameters.abtest_tidb_config}}"
-                - name: abtest_tikv_config
-                  value: "{{workflow.parameters.abtest_tikv_config}}"
-                - name: abtest_pd_config
-                  value: "{{workflow.parameters.abtest_pd_config}}"
-                - name: abtest_general_log
-                  value: "{{workflow.parameters.abtest_general_log}}"
-                - name: tiflash_image
-                  value: "{{workflow.parameters.tiflash_image}}"
-                - name: tiflash_replicas
-                  value: "{{workflow.parameters.tiflash_replicas}}"
+                - name: tidb-config
+                  value: "{{workflow.parameters.tidb-config}}"
+                - name: tikv-config
+                  value: "{{workflow.parameters.tikv-config}}"
+                - name: pd-config
+                  value: "{{workflow.parameters.pd-config}}"
+                - name: abtest_tidb-config
+                  value: "{{workflow.parameters.abtest_tidb-config}}"
+                - name: abtest_tikv-config
+                  value: "{{workflow.parameters.abtest_tikv-config}}"
+                - name: abtest_pd-config
+                  value: "{{workflow.parameters.abtest_pd-config}}"
+                - name: abtest_general-log
+                  value: "{{workflow.parameters.abtest_general-log}}"
+                - name: tiflash-image
+                  value: "{{workflow.parameters.tiflash-image}}"
+                - name: tiflash-replicas
+                  value: "{{workflow.parameters.tiflash-replicas}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username

--- a/argo/workflow/tiflash-cdc.yaml
+++ b/argo/workflow/tiflash-cdc.yaml
@@ -9,39 +9,39 @@ spec:
         value: tipocket-tiflash-cdc
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: release-4.0-nightly
-      - name: tidb_image
+      - name: tidb-image
         value: ""
-      - name: tikv_image
+      - name: tikv-image
         value: ""
-      - name: pd_image
+      - name: pd-image
         value: ""
-      - name: storage_class
+      - name: storage-class
         value: gp2
-      - name: abtest_version
+      - name: abtest_image-version
         value: release-4.0-nightly
       - name: nemesis
         value: ""
       - name: client
         value: "2"
-      - name: tidb_config
+      - name: tidb-config
         value: ""
-      - name: tikv_config
+      - name: tikv-config
         value: ""
-      - name: pd_config
+      - name: pd-config
         value: ""
-      - name: abtest_tidb_config
+      - name: abtest_tidb-config
         value: ""
-      - name: abtest_tikv_config
+      - name: abtest_tikv-config
         value: ""
-      - name: abtest_pd_config
+      - name: abtest_pd-config
         value: ""
-      - name: abtest_general_log
+      - name: abtest_general-log
         value: "true"
-      - name: tiflash_image
+      - name: tiflash-image
         value: "v4.0.0-rc"
-      - name: tiflash_replicas
+      - name: tiflash-replicas
         value: 2
       - name: cdc_hub
         value: "docker.io"
@@ -68,40 +68,40 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: tidb_image
-                  value: "{{workflow.parameters.tidb_image}}"
-                - name: tikv_image
-                  value: "{{workflow.parameters.tikv_image}}"
-                - name: pd_image
-                  value: "{{workflow.parameters.pd_image}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
-                - name: abtest_version
-                  value: "{{workflow.parameters.abtest_version}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: tidb-image
+                  value: "{{workflow.parameters.tidb-image}}"
+                - name: tikv-image
+                  value: "{{workflow.parameters.tikv-image}}"
+                - name: pd-image
+                  value: "{{workflow.parameters.pd-image}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
+                - name: abtest_image-version
+                  value: "{{workflow.parameters.abtest_image-version}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
                 - name: client
                   value: "{{workflow.parameters.client}}"
-                - name: tidb_config
-                  value: "{{workflow.parameters.tidb_config}}"
-                - name: tikv_config
-                  value: "{{workflow.parameters.tikv_config}}"
-                - name: pd_config
-                  value: "{{workflow.parameters.pd_config}}"
-                - name: abtest_tidb_config
-                  value: "{{workflow.parameters.abtest_tidb_config}}"
-                - name: abtest_tikv_config
-                  value: "{{workflow.parameters.abtest_tikv_config}}"
-                - name: abtest_pd_config
-                  value: "{{workflow.parameters.abtest_pd_config}}"
-                - name: abtest_general_log
-                  value: "{{workflow.parameters.abtest_general_log}}"
-                - name: tiflash_image
-                  value: "{{workflow.parameters.tiflash_image}}"
-                - name: tiflash_replicas
-                  value: "{{workflow.parameters.tiflash_replicas}}"
+                - name: tidb-config
+                  value: "{{workflow.parameters.tidb-config}}"
+                - name: tikv-config
+                  value: "{{workflow.parameters.tikv-config}}"
+                - name: pd-config
+                  value: "{{workflow.parameters.pd-config}}"
+                - name: abtest_tidb-config
+                  value: "{{workflow.parameters.abtest_tidb-config}}"
+                - name: abtest_tikv-config
+                  value: "{{workflow.parameters.abtest_tikv-config}}"
+                - name: abtest_pd-config
+                  value: "{{workflow.parameters.abtest_pd-config}}"
+                - name: abtest_general-log
+                  value: "{{workflow.parameters.abtest_general-log}}"
+                - name: tiflash-image
+                  value: "{{workflow.parameters.tiflash-image}}"
+                - name: tiflash-replicas
+                  value: "{{workflow.parameters.tiflash-replicas}}"
                 - name: cdc_hub
                   value: "{{workflow.parameters.cdc_hub}}"
                 - name: cdc_repository

--- a/argo/workflow/tiflash.yaml
+++ b/argo/workflow/tiflash.yaml
@@ -9,17 +9,17 @@ spec:
         value: tipocket-tiflash
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: release-4.0-nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
       - name: nemesis
         value: ""
-      - name: run_time
+      - name: run-time
         value: "6h"
-      - name: tiflash_image
+      - name: tiflash-image
         value: "v4.0.0-rc"
-      - name: tiflash_replicas
+      - name: tiflash-replicas
         value: 2
       - name: loki-addr
         value: "http://gateway.loki.svc"
@@ -40,18 +40,18 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
-                - name: run_time
-                  value: "{{workflow.parameters.run_time}}"
-                - name: tiflash_image
-                  value: "{{workflow.parameters.tiflash_image}}"
-                - name: tiflash_replicas
-                  value: "{{workflow.parameters.tiflash_replicas}}"
+                - name: run-time
+                  value: "{{workflow.parameters.run-time}}"
+                - name: tiflash-image
+                  value: "{{workflow.parameters.tiflash-image}}"
+                - name: tiflash-replicas
+                  value: "{{workflow.parameters.tiflash-replicas}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username

--- a/argo/workflow/titan-bank.yaml
+++ b/argo/workflow/titan-bank.yaml
@@ -9,15 +9,15 @@ spec:
         value: tipocket-titan-bank
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: release-4.0-nightly
-      - name: storage_class
+      - name: storage-class
         value: local-storage
       - name: nemesis
         value: "short_kill_tikv_1node,mixed_tikv,shuffle-region-scheduler,kill_tikv_1node_5min"
       - name: client
         value: "5"
-      - name: request_count
+      - name: request-count
         value: "10000"
       - name: round
         value: "100"
@@ -44,16 +44,16 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
                 - name: client
                   value: "{{workflow.parameters.client}}"
-                - name: request_count
-                  value: "{{workflow.parameters.request_count}}"
+                - name: request-count
+                  value: "{{workflow.parameters.request-count}}"
                 - name: round
                   value: "{{workflow.parameters.round}}"
                 - name: loki-addr

--- a/argo/workflow/tpcc.yaml
+++ b/argo/workflow/tpcc.yaml
@@ -9,15 +9,15 @@ spec:
         value: tipocket-tpcc
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: release-4.0-nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
       - name: nemesis
         value: random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler
       - name: client
         value: "100"
-      - name: request_count
+      - name: request-count
         value: "1000000"
       - name: round
         value: "10"
@@ -40,16 +40,16 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
                 - name: client
                   value: "{{workflow.parameters.client}}"
-                - name: request_count
-                  value: "{{workflow.parameters.request_count}}"
+                - name: request-count
+                  value: "{{workflow.parameters.request-count}}"
                 - name: round
                   value: "{{workflow.parameters.round}}"
                 - name: loki-addr

--- a/argo/workflow/txn-rand-pessimistic.yaml
+++ b/argo/workflow/txn-rand-pessimistic.yaml
@@ -9,13 +9,13 @@ spec:
         value: tipocket-txn-rand-pessimistic
       - name: purge
         value: "true"
-      - name: image_version
+      - name: image-version
         value: release-4.0-nightly
-      - name: storage_class
+      - name: storage-class
         value: gp2
       - name: nemesis
         value: random_kill,kill_pd_leader_5min,partition_one,subcritical_skews,big_skews,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler
-      - name: run_time
+      - name: run-time
         value: "4h"
       - name: loki-addr
         value: "http://gateway.loki.svc"
@@ -36,14 +36,14 @@ spec:
                   value: "{{workflow.parameters.ns}}"
                 - name: purge
                   value: "{{workflow.parameters.purge}}"
-                - name: image_version
-                  value: "{{workflow.parameters.image_version}}"
-                - name: storage_class
-                  value: "{{workflow.parameters.storage_class}}"
+                - name: image-version
+                  value: "{{workflow.parameters.image-version}}"
+                - name: storage-class
+                  value: "{{workflow.parameters.storage-class}}"
                 - name: nemesis
                   value: "{{workflow.parameters.nemesis}}"
-                - name: run_time
-                  value: "{{workflow.parameters.run_time}}"
+                - name: run-time
+                  value: "{{workflow.parameters.run-time}}"
                 - name: loki-addr
                   value: "{{workflow.parameters.loki-addr}}"
                 - name: loki-username


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Fixes https://github.com/pingcap/tipocket/pull/245#discussion_r428067101

Unify the parameters between tipocket and argo.

Note that for the flag with `.` such as `cdc.version` or `abtest.general-log`, I rename `.` to `_` such as `cdc_version` or `abtest_general-log` because argo name doesn't allow `.`