### PR TITLE
Enc nemesis

### DIFF
--- a/argo/workflow/encryption/bank-tikv-encryption.yaml
+++ b/argo/workflow/encryption/bank-tikv-encryption.yaml
@@ -14,7 +14,7 @@ spec:
       - name: storage-class
         value: local-storage
       - name: nemesis
-        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,delay_tikv,readerr_tikv"
+        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,delay_tikv"
       - name: tikv-config
         value: "/config/tikv/encryption.toml"
   templates:

--- a/argo/workflow/encryption/bank-tikv-encryption.yaml
+++ b/argo/workflow/encryption/bank-tikv-encryption.yaml
@@ -14,7 +14,7 @@ spec:
       - name: storage-class
         value: local-storage
       - name: nemesis
-        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,mixed_tikv"
+        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,delay_tikv,readerr_tikv"
       - name: tikv-config
         value: "/config/tikv/encryption.toml"
   templates:

--- a/argo/workflow/encryption/bank2-tikv-encryption.yaml
+++ b/argo/workflow/encryption/bank2-tikv-encryption.yaml
@@ -14,7 +14,7 @@ spec:
       - name: storage-class
         value: local-storage
       - name: nemesis
-        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,delay_tikv,readerr_tikv"
+        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,delay_tikv"
       - name: tikv-config
         value: "/config/tikv/encryption.toml"
   templates:

--- a/argo/workflow/encryption/bank2-tikv-encryption.yaml
+++ b/argo/workflow/encryption/bank2-tikv-encryption.yaml
@@ -14,7 +14,7 @@ spec:
       - name: storage-class
         value: local-storage
       - name: nemesis
-        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,mixed_tikv"
+        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,delay_tikv,readerr_tikv"
       - name: tikv-config
         value: "/config/tikv/encryption.toml"
   templates:

--- a/argo/workflow/encryption/tiflash-tikv-encryption.yaml
+++ b/argo/workflow/encryption/tiflash-tikv-encryption.yaml
@@ -14,7 +14,7 @@ spec:
       - name: storage-class
         value: local-storage
       - name: nemesis
-        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,delay_tikv,readerr_tikv"
+        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,delay_tikv"
       - name: tikv-config
         value: "/config/tikv/encryption.toml"
   templates:

--- a/argo/workflow/encryption/tiflash-tikv-encryption.yaml
+++ b/argo/workflow/encryption/tiflash-tikv-encryption.yaml
@@ -14,7 +14,7 @@ spec:
       - name: storage-class
         value: local-storage
       - name: nemesis
-        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,mixed_tikv"
+        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,delay_tikv,readerr_tikv"
       - name: tikv-config
         value: "/config/tikv/encryption.toml"
   templates:

--- a/argo/workflow/encryption/tpcc-tikv-encryption.yaml
+++ b/argo/workflow/encryption/tpcc-tikv-encryption.yaml
@@ -14,7 +14,7 @@ spec:
       - name: storage-class
         value: local-storage
       - name: nemesis
-        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,delay_tikv,readerr_tikv"
+        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,delay_tikv"
       - name: tikv-config
         value: "/config/tikv/encryption.toml"
   templates:

--- a/argo/workflow/encryption/tpcc-tikv-encryption.yaml
+++ b/argo/workflow/encryption/tpcc-tikv-encryption.yaml
@@ -14,7 +14,7 @@ spec:
       - name: storage-class
         value: local-storage
       - name: nemesis
-        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,mixed_tikv"
+        value: "random_kill,shuffle-leader-scheduler,shuffle-region-scheduler,random-merge-scheduler,delay_tikv,readerr_tikv"
       - name: tikv-config
         value: "/config/tikv/encryption.toml"
   templates:


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

IO error will cause tikv panic (expected behavior) and tipocket case failure. Update encryption tests's nemesis to use `delay_tikv` instead

### What is changed and how does it work?

change encryption tests' nemesis to use `delay_tikv` instead of `mixed_tikv`.

### Does this PR introduce a user-facing change?:
no
