### PR TITLE
Fix: support controlling nemesis on client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/satori/go.uuid v1.2.0
 	github.com/stretchr/testify v1.5.1
 	github.com/tikv/client-go v0.0.0-20200110101306-a3ebdb020c83
-	github.com/uber-go/atomic v1.5.0 // indirect
+	github.com/uber-go/atomic v1.5.0
 	go.uber.org/zap v1.14.0
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e

--- a/pkg/core/nemesis.go
+++ b/pkg/core/nemesis.go
@@ -3,8 +3,9 @@ package core
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
+
+	"github.com/uber-go/atomic"
 
 	clusterTypes "github.com/pingcap/tipocket/pkg/cluster/types"
 )
@@ -68,6 +69,79 @@ func GetNemesis(name string) Nemesis {
 	return nemesises[name]
 }
 
+const (
+	waitForStart   = 1
+	enableStart    = 2
+	starting       = 3
+	enableRollback = 4
+)
+
+// NemesisControl is used to operate nemesis between the control side and test client side
+type NemesisControl struct {
+	// 0: wait for start
+	// 1: enable start
+	// 2: starting
+	// 3: enable rollback
+	s atomic.Int32
+}
+
+// WaitForStart is used on control side to wait for enabling start nemesis
+func (n *NemesisControl) WaitForStart() {
+	// init state
+	n.s.Store(waitForStart)
+	for {
+		if n.s.CAS(enableStart, starting) {
+			return
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+// WaitForRollback is used on control side to wait for enabling rollback nemesis
+func (n *NemesisControl) WaitForRollback(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			if n.s.Load() == enableRollback {
+				return
+			}
+			time.Sleep(time.Second)
+		}
+	}
+}
+
+// Start is used on client side to enable control side starting nemesis
+func (n *NemesisControl) Start(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			if n.s.CAS(waitForStart, enableStart) {
+				return
+			}
+			time.Sleep(time.Second)
+		}
+	}
+}
+
+// Rollback is used on client side to enable control side rollbacking nemesis
+func (n *NemesisControl) Rollback(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			if n.s.CAS(starting, enableRollback) {
+				return
+			}
+			time.Sleep(time.Second)
+		}
+	}
+}
+
 // NemesisOperation is nemesis operation used in control.
 type NemesisOperation struct {
 	Type        ChaosKind          // Nemesis name
@@ -77,9 +151,9 @@ type NemesisOperation struct {
 
 	// We have two approaches to trigger recovery
 	// 1. through `RunTime`
-	// 2. through `RecoveryCh`
-	RunTime    time.Duration      // Nemesis duration time
-	RecoveryCh <-chan interface{} // Nemesis recovery trigger
+	// 2. through `NemesisControl` WaitForRollback
+	RunTime        time.Duration   // Nemesis duration time
+	NemesisControl *NemesisControl // Nemesis recovery signal
 }
 
 // String ...
@@ -122,17 +196,21 @@ func (d DelayNemesisGenerator) Name() string {
 // NemesisGenerators is a NemesisGenerator iterator
 type NemesisGenerators interface {
 	Next() NemesisGenerator
+	HasNext() bool
 }
 
-// ImmutableNemesisGenerators is a wrapper of []NemesisGenerator
-type ImmutableNemesisGenerators struct {
+// nemesisGenerators is a wrapper of []NemesisGenerator
+type nemesisGenerators struct {
 	idx        int
 	generators []NemesisGenerator
 }
 
+func (i *nemesisGenerators) HasNext() bool {
+	return i.idx < len(i.generators)
+}
+
 // Next ...
-func (i *ImmutableNemesisGenerators) Next() NemesisGenerator {
-	i.idx = i.idx % len(i.generators)
+func (i *nemesisGenerators) Next() NemesisGenerator {
 	gen := i.generators[i.idx]
 	i.idx += 1
 	return gen
@@ -140,35 +218,33 @@ func (i *ImmutableNemesisGenerators) Next() NemesisGenerator {
 
 // NewNemesisGenerators ...
 func NewNemesisGenerators(gens []NemesisGenerator) NemesisGenerators {
-	return &ImmutableNemesisGenerators{
+	return &nemesisGenerators{
 		idx:        0,
 		generators: gens,
 	}
 }
 
-// MutableNemesisGenerators can be used to interact between client and control
-type MutableNemesisGenerators struct {
-	sync.RWMutex
-	gen NemesisGenerator
+// OneRoundNemesisGenerators is easier than nemesisGenerators, and suitable in cases that need to interact between client and control
+type OneRoundNemesisGenerators struct {
+	gen     NemesisGenerator
+	hasNext bool
+}
+
+// HasNext ...
+func (m *OneRoundNemesisGenerators) HasNext() bool {
+	return m.hasNext
 }
 
 // Next ...
-func (m *MutableNemesisGenerators) Next() NemesisGenerator {
-	m.RLock()
-	defer m.RUnlock()
+func (m *OneRoundNemesisGenerators) Next() NemesisGenerator {
+	m.hasNext = false
 	return m.gen
 }
 
-// Set ...
-func (m *MutableNemesisGenerators) Set(gen NemesisGenerator) {
-	m.Lock()
-	defer m.Unlock()
-	m.gen = gen
-}
-
-// NewMutableNemesisGenerators ...
-func NewMutableNemesisGenerators(init NemesisGenerator) NemesisGenerators {
-	return &MutableNemesisGenerators{
-		gen: init,
+// NewOneRoundNemesisGenerators ...
+func NewOneRoundNemesisGenerators(gen NemesisGenerator) NemesisGenerators {
+	return &OneRoundNemesisGenerators{
+		gen:     gen,
+		hasNext: true,
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

### What is changed and how does it work?

There is a bug in the previous PR: https://github.com/pingcap/tipocket/pull/262, because there uses a channel to trigger the recovery of nemesis, only one nemesis maybe recover, and another nemesis is pending forever.

Here is a simple demo showing how to control nemesis in test client:

```go
func (c *Case) Start(ctx context.Context, cfg interface{}, clientNodes []types.ClientNode) error {
	control := ctx.Value("control").(*control.Controller)

	for i := 1; i <= 3; i++ {
		killGenerator, nemesisControl := nemesis.NewCoordinationKillGenerator(c.nodes[0:i])
		control.UpdateNemesisGenerators(core.NewOneRoundNemesisGenerators(killGenerator))
		// Start blocks until nemesis is prepared to start
		nemesisControl.Start(ctx)

		log.Info("nemesis starts")
		time.Sleep(5 * time.Minute)
		log.Info("5 minutes later...")

		// recover nemesis, but won't block.
		nemesisControl.Rollback(ctx)
                ...
	}
        ...
}
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
