### PR TITLE
Fix: invalid advertise-status-addr

### DIFF
--- a/pkg/test-infra/tidb/template.go
+++ b/pkg/test-infra/tidb/template.go
@@ -221,6 +221,7 @@ POD_NAME=${POD_NAME:-$HOSTNAME}
 ARGS="--pd=http://${CLUSTER_NAME}-pd:2379 \
 --advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20160 \
 --addr=0.0.0.0:20160 \
+--advertise-status-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20180 \
 --status-addr=0.0.0.0:20180 \
 --data-dir={{.DataDir}} \
 --capacity=${CAPACITY} \


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Sees:  https://github.com/tikv/tikv/pull/7944

Because of lack of `advertise-status-addr`, tikv-server uses status-addr as the fallback, and its value is set to "0.0.0.0:20180" which causes a panic when starts the tikv-server.

BTW, I don't know when will https://github.com/tikv/tikv/pull/7944 merge into release-4.0, so this PR will make it fail when testing on release-4.0 TiDB-cluster.

```log
[2020/06/04 03:33:03.085 +00:00] [INFO] [config.rs:202] ["no advertise-status-addr is specified, falling back to status-addr"] [status-addr=0.0.0.0:20180]
[2020/06/04 03:33:03.085 +00:00] [FATAL] [setup.rs:204] ["invalid configuration: \"[src/server/config.rs:209]: invalid advertise-status-addr: \\\"0.0.0.0:20180\\\"\""]
```

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
