### PR TITLE
Support to set different dc labels on TiKV nodes

### DIFF
--- a/pkg/test-infra/fixture/fixture.go
+++ b/pkg/test-infra/fixture/fixture.go
@@ -94,6 +94,9 @@ type TiDBClusterConfig struct {
 	TiKVReplicas    int
 	PDReplicas      int
 	TiFlashReplicas int
+
+	// Data center count
+	DataCenter int
 }
 
 // Context ...
@@ -238,6 +241,7 @@ func init() {
 	flag.IntVar(&Context.TiDBClusterConfig.TiKVReplicas, "tikv-replicas", 3, "number of tikv replicas")
 	flag.IntVar(&Context.TiDBClusterConfig.PDReplicas, "pd-replicas", 3, "number of pd replicas")
 	flag.IntVar(&Context.TiDBClusterConfig.TiFlashReplicas, "tiflash-replicas", 0, "number of tiflash replicas, set 0 to disable tiflash")
+	flag.IntVar(&Context.TiDBClusterConfig.DataCenter, "data-center", 1, "number of data centers")
 
 	flag.StringVar(&Context.ABTestConfig.ClusterBConfig.ImageVersion, "abtest.image-version", "", "specify version for cluster B")
 	flag.StringVar(&Context.ABTestConfig.ClusterBConfig.TiDBConfig, "abtest.tidb-config", "", "tidb config file for cluster B")

--- a/pkg/test-infra/tidb/operation.go
+++ b/pkg/test-infra/tidb/operation.go
@@ -508,7 +508,12 @@ func getTiDBConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
 }
 
 func getTiKVConfigMap(tc *v1alpha1.TidbCluster) (*corev1.ConfigMap, error) {
-	scriptModel := &TiKVStartScriptModel{DataDir: tikvDir, MasterKey: tikvEncryptionMasterKey}
+	scriptModel := &TiKVStartScriptModel{
+		DataDir:    tikvDir,
+		MasterKey:  tikvEncryptionMasterKey,
+		Replicas:   tc.Spec.TiKV.Replicas,
+		DataCenter: fixture.Context.TiDBClusterConfig.DataCenter,
+	}
 	if getIOChaosAnnotation(tc, "tikv") == "chaosfs-tikv" {
 		scriptModel.DataDir = tikvDataDir
 	}

--- a/pkg/test-infra/tidb/template.go
+++ b/pkg/test-infra/tidb/template.go
@@ -218,6 +218,8 @@ fi
 
 # Use HOSTNAME if POD_NAME is unset for backward compatibility.
 POD_NAME=${POD_NAME:-$HOSTNAME}
+# Use for multiple data center testing
+DC_ID=$(expr $(echo $POD_NAME | grep -Eo '[0-9]+$') / {{.DataCenter}})
 ARGS="--pd=http://${CLUSTER_NAME}-pd:2379 \
 --advertise-addr=${POD_NAME}.${HEADLESS_SERVICE_NAME}.${NAMESPACE}.svc:20160 \
 --addr=0.0.0.0:20160 \
@@ -225,7 +227,8 @@ ARGS="--pd=http://${CLUSTER_NAME}-pd:2379 \
 --status-addr=0.0.0.0:20180 \
 --data-dir={{.DataDir}} \
 --capacity=${CAPACITY} \
---config=/etc/tikv/tikv.toml
+--config=/etc/tikv/tikv.toml \
+--labels=dc=${DC_ID}
 "
 
 echo "starting tikv-server ..."
@@ -235,8 +238,10 @@ exec /tikv-server ${ARGS}
 
 // TiKVStartScriptModel ...
 type TiKVStartScriptModel struct {
-	DataDir   string
-	MasterKey string
+	DataDir    string
+	MasterKey  string
+	Replicas   int32
+	DataCenter int
 }
 
 // RenderTiKVStartScript ...


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

### What is changed and how does it work?

This PR provides a hack way to set different labels on different TiKV nodes.

It means to test two data center cluster, someone needs to set `-data-center=2`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
