### PR TITLE
Add hub args for components

### DIFF
--- a/pkg/test-infra/fixture/fixture.go
+++ b/pkg/test-infra/fixture/fixture.go
@@ -77,6 +77,12 @@ type fixtureContext struct {
 
 // TiDBClusterConfig ...
 type TiDBClusterConfig struct {
+	// hub address
+	TiDBHubAddress    string
+	TiKVHubAddress    string
+	PDHubAddress      string
+	TiFlashHubAddress string
+
 	// image versions
 	ImageVersion string
 	TiDBImage    string
@@ -211,7 +217,6 @@ func init() {
 
 	flag.StringVar(&Context.Namespace, "namespace", "", "test namespace")
 	flag.StringVar(&Context.MySQLVersion, "mysql-version", "5.6", "Default mysql version")
-	flag.StringVar(&Context.HubAddress, "hub", "", "hub address, default to docker hub")
 	flag.StringVar(&Context.DockerRepository, "repository", "pingcap", "repo name, default is pingcap")
 	flag.StringVar(&Context.LocalVolumeStorageClass, "storage-class", "local-storage", "storage class name")
 	flag.StringVar(&Context.TiDBMonitorSvcType, "monitor-svc", "ClusterIP", "TiDB monitor service type")
@@ -224,6 +229,12 @@ func init() {
 	flag.StringVar(&Context.LokiAddress, "loki-addr", "", "loki address. If empty then don't query logs from loki.")
 	flag.StringVar(&Context.LokiUsername, "loki-username", "", "loki username. Needed when basic auth is configured in loki")
 	flag.StringVar(&Context.LokiPassword, "loki-password", "", "loki password. Needed when basic auth is configured in loki")
+
+	flag.StringVar(&Context.HubAddress, "hub", "", "hub address, default to docker hub")
+	flag.StringVar(&Context.TiDBClusterConfig.TiDBHubAddress, "tidb-hub", "", "tidb hub address, will overwrite -hub")
+	flag.StringVar(&Context.TiDBClusterConfig.TiKVHubAddress, "tikv-hub", "", "tikv hub address, will overwrite -hub")
+	flag.StringVar(&Context.TiDBClusterConfig.PDHubAddress, "pd-hub", "", "pd hub address, will overwrite -hub")
+	flag.StringVar(&Context.TiDBClusterConfig.TiFlashHubAddress, "tiflash-hub", "", "tiflash hub address, will overwrite -hub")
 
 	flag.StringVar(&Context.TiDBClusterConfig.ImageVersion, "image-version", "nightly", "image version")
 	flag.StringVar(&Context.TiDBClusterConfig.TiDBImage, "tidb-image", "", "tidb image")

--- a/pkg/test-infra/util/util.go
+++ b/pkg/test-infra/util/util.go
@@ -102,8 +102,9 @@ func BuildImage(name, tag, fullImageIfNotEmpty string) string {
 		return fullImageIfNotEmpty
 	}
 	var b strings.Builder
-	if fixture.Context.HubAddress != "" {
-		fmt.Fprintf(&b, "%s/", fixture.Context.HubAddress)
+	hub := chooseHub(name)
+	if hub != "" {
+		fmt.Fprintf(&b, "%s/", hub)
 	}
 	b.WriteString(fixture.Context.DockerRepository)
 	b.WriteString("/")
@@ -112,6 +113,28 @@ func BuildImage(name, tag, fullImageIfNotEmpty string) string {
 	b.WriteString(tag)
 
 	return b.String()
+}
+
+func chooseHub(image string) string {
+	switch image {
+	case "tidb":
+		if fixture.Context.TiDBClusterConfig.TiDBHubAddress != "" {
+			return fixture.Context.TiDBClusterConfig.TiDBHubAddress
+		}
+	case "tikv":
+		if fixture.Context.TiDBClusterConfig.TiKVHubAddress != "" {
+			return fixture.Context.TiDBClusterConfig.TiKVHubAddress
+		}
+	case "pd":
+		if fixture.Context.TiDBClusterConfig.PDHubAddress != "" {
+			return fixture.Context.TiDBClusterConfig.PDHubAddress
+		}
+	case "tiflash":
+		if fixture.Context.TiDBClusterConfig.TiFlashHubAddress != "" {
+			return fixture.Context.TiDBClusterConfig.TiFlashHubAddress
+		}
+	}
+	return fixture.Context.HubAddress
 }
 
 // GetNodeIPs gets the IPs (or addresses) for nodes.


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

The hub address for components can be used for testing an edited component with others default component such as from docker.io.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
