### PR TITLE
Fix: remove duplicate unlock

### DIFF
--- a/pkg/pocket/core/check.go
+++ b/pkg/pocket/core/check.go
@@ -236,8 +236,6 @@ SYNC:
 		// return false, errors.Trace(err)
 	}
 	if err := compareExecutor.ABTestTxnBegin(); err != nil {
-		c.Unlock()
-		c.execMutex.Unlock()
 		return false, errors.Trace(err)
 	}
 	log.Info("compare wait for chan finish")


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Fix the duplicate unlock lock issue. Because there exists a defer function, so I remove the unlock statements.

``` go
	defer func() {
		log.Info("free lock")
		c.Unlock()
		c.execMutex.Unlock()
	}()
```

```
2020/06/23 12:00:10 check.go:191: [info] free lock 
fatal error: sync: unlock of unlocked mutex

goroutine 1741187 [running]:
runtime.throw(0x298b621, 0x1e)
	/usr/local/go/src/runtime/panic.go:774 +0x72 fp=0xc002575b20 sp=0xc002575af0 pc=0x4313d2
sync.throw(0x298b621, 0x1e)
	/usr/local/go/src/runtime/panic.go:760 +0x35 fp=0xc002575b40 sp=0xc002575b20 pc=0x431355
sync.(*Mutex).unlockSlow(0xc000282058, 0xc0ffffffff)
	/usr/local/go/src/sync/mutex.go:196 +0xd6 fp=0xc002575b68 sp=0xc002575b40 pc=0x46ffe6
sync.(*Mutex).Unlock(...)
	/usr/local/go/src/sync/mutex.go:190
github.com/pingcap/tipocket/pkg/pocket/core.(*Core).Unlock(0xc000282000)
	/src/pkg/pocket/core/lock.go:25 +0x51 fp=0xc002575b88 sp=0xc002575b68 pc=0x1a77831
github.com/pingcap/tipocket/pkg/pocket/core.(*Core).binlogTestCompareData.func2(0xc000282000)
	/src/pkg/pocket/core/check.go:192 +0x84 fp=0xc002575bd0 sp=0xc002575b88 pc=0x1a7a9a4
github.com/pingcap/tipocket/pkg/pocket/core.(*Core).binlogTestCompareData(0xc000282000, 0x0, 0x2946300, 0x2d5de00, 0xc0024fcf00)
	/src/pkg/pocket/core/check.go:241 +0x521 fp=0xc002575de8 sp=0xc002575bd0 pc=0x1a71fd1
github.com/pingcap/tipocket/pkg/pocket/core.(*Core).checkConsistency(0xc000282000, 0x7f24e0b58b00, 0x0, 0xc0022d3ef0, 0x50599b)
	/src/pkg/pocket/core/check.go:76 +0xd2 fp=0xc002575e38 sp=0xc002575de8 pc=0x1a713a2
github.com/pingcap/tipocket/pkg/pocket/core.(*Core).startCheckConsistency.func1.1(0xc0022d3ec0, 0x7ae5bd, 0x26734e0)
	/src/pkg/pocket/core/check.go:50 +0x45 fp=0xc002575ea0 sp=0xc002575e38 pc=0x1a7a315
k8s.io/apimachinery/pkg/util/wait.pollImmediateInternal(0xc00158c740, 0xc002575f98, 0xc00158c740, 0xc0022d3e78)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.0/pkg/util/wait/wait.go:338 +0x2b fp=0xc002575ed0 sp=0xc002575ea0 pc=0x7ae2ab
k8s.io/apimachinery/pkg/util/wait.PollImmediate(0xdf8475800, 0x8bb2c97000, 0xc0022d3f98, 0x1, 0x1)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.0/pkg/util/wait/wait.go:334 +0x4d fp=0xc002575f00 sp=0xc002575ed0 pc=0x7ae24d
github.com/pingcap/tipocket/pkg/pocket/core.(*Core).startCheckConsistency.func1(0xc000282000, 0xc00119c000, 0x139)
	/src/pkg/pocket/core/check.go:49 +0x109 fp=0xc002575fc8 sp=0xc002575f00 pc=0x1a7a539
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc002575fd0 sp=0xc002575fc8 pc=0x461081
created by github.com/pingcap/tipocket/pkg/pocket/core.(*Core).startCheckConsistency
	/src/pkg/pocket/core/check.go:42 +0xf1
```

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
