### PR TITLE
fix metadata name in cdc file sort test

### DIFF
--- a/argo/cron/cdc-file-sort.yaml
+++ b/argo/cron/cdc-file-sort.yaml
@@ -1,5 +1,5 @@
 metadata:
-  name: tipocket-cdc
+  name: tipocket-cdc-file-sort
 spec:
   schedule: "0 6 * * *"
   concurrencyPolicy: "Forbid"


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

Fix metadata name conflict

### What is changed and how does it work?

use `tipocket-cdc-file-sort` in file sort test

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test

### Does this PR introduce a user-facing change?:

- release-note
    NONE