### PR TITLE
elle: fix lock some keys on failed txn

### DIFF
--- a/tests/list_append/append.go
+++ b/tests/list_append/append.go
@@ -108,6 +108,7 @@ func (c *client) Invoke(ctx context.Context, node cluster.ClientNode, r interfac
 			_, err := txn.ExecContext(ctx, fmt.Sprintf("insert into txn_%d(id, sk, val) values (?, ?, ?) on duplicate key update val = CONCAT(val, ',', ?)",
 				table), k, k, v, v)
 			if err != nil {
+				_ = txn.Rollback()
 				return appendResponse{
 					Result: ellecore.Op{
 						Time:  time.Now(),
@@ -134,6 +135,7 @@ func (c *client) Invoke(ctx context.Context, node cluster.ClientNode, r interfac
 			}
 			rows, err := txn.QueryContext(ctx, query, k)
 			if err != nil {
+				_ = txn.Rollback()
 				return appendResponse{
 					Result: ellecore.Op{
 						Time:  time.Now(),

--- a/tests/rw_register/register.go
+++ b/tests/rw_register/register.go
@@ -102,6 +102,7 @@ func (c *client) Invoke(ctx context.Context, node cluster.ClientNode, r interfac
 			v := mop.GetValue().(elleregister.Int).MustGetVal()
 			_, err := txn.ExecContext(ctx, "insert into register(id, sk, val) values (?, ?, ?) on duplicate key update val = ?", k, k, v, v)
 			if err != nil {
+				_ = txn.Rollback()
 				return registerResponse{
 					Result: ellecore.Op{
 						Time:  time.Now(),
@@ -130,6 +131,7 @@ func (c *client) Invoke(ctx context.Context, node cluster.ClientNode, r interfac
 			}
 			rows, err := txn.QueryContext(ctx, query, k)
 			if err != nil {
+				_ = txn.Rollback()
 				return registerResponse{
 					Result: ellecore.Op{
 						Time:  time.Now(),


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

When a transaction failed after some successful operations, it should be rollbacked, otherwise some keys will be permanently locked.

### What is changed and how does it work?

Rollback transactions when it got failed.

### Check List <!--REMOVE the items that are not applicable-->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Side effects

 - No

Related changes

 - No

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
