### PR TITLE
Apiserver: inject artifact URL into workload containers and add tearDown

### DIFF
--- a/pkg/cluster/manager/apiserver/artifact.go
+++ b/pkg/cluster/manager/apiserver/artifact.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/juju/errors"
-	"github.com/rogpeppe/fastuuid"
 	"go.uber.org/zap"
 
 	"github.com/pingcap/tipocket/pkg/cluster/manager/artifacts"
@@ -60,8 +59,8 @@ func (m *Manager) archiveArtifacts(
 	topos *deploy.Topology,
 	wr *types.WorkloadRequest,
 	dockerExecutor *util.DockerExecutor,
-	containerID string) error {
-	artifactUUID := fastuuid.MustNewGenerator().Hex128()
+	containerID string,
+	artifactUUID string) error {
 	s3Client, err := artifacts.NewS3Client()
 	if err != nil {
 		return errors.Trace(err)

--- a/pkg/cluster/manager/artifacts/monitor.go
+++ b/pkg/cluster/manager/artifacts/monitor.go
@@ -36,6 +36,11 @@ func ArtifactPath(crID uint) string {
 	return fmt.Sprintf("minio/artifacts/%d", crID)
 }
 
+// ArtifactDownloadPath builds artifact download dir
+func ArtifactDownloadPath(crID uint) string {
+	return fmt.Sprintf("artifacts/%d", crID)
+}
+
 // ArchiveMonitorData archives prometheus data and grafana configuration(including dashboards and provisioning)
 func ArchiveMonitorData(s3Client *S3Client, crID uint, uuid string, topos *deploy.Topology) (err error) {
 	var (
@@ -96,18 +101,18 @@ func ArchiveWorkloadData(s3Client *S3Client, dockerExecutor *util.DockerExecutor
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(tmpDir, func(p string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 		if info.IsDir() {
 			return nil
 		}
-		path, err = filepath.Rel(tmpDir, path)
+		p, err = filepath.Rel(tmpDir, p)
 		_, err = s3Client.FPutObject(context.Background(),
 			"artifacts",
-			fmt.Sprintf("%d/%s/%s", crID, uuid, path),
-			path,
+			fmt.Sprintf("%d/%s/%s", crID, uuid, p),
+			path.Join(tmpDir, p),
 			minio.PutObjectOptions{},
 		)
 		if err != nil {

--- a/pkg/cluster/manager/types/workload.go
+++ b/pkg/cluster/manager/types/workload.go
@@ -8,8 +8,18 @@ import (
 	"github.com/juju/errors"
 )
 
+const (
+	// WorkloadTypeStandard default value
+	WorkloadTypeStandard = "standard"
+	// WorkloadTypePR run with baseline
+	WorkloadTypePR = "PR"
+)
+
 // Args is used to encapsulate the docker container instance args
 type Args []string
+
+// Envs is map[string]string
+type Envs map[string]string
 
 // Value ...
 func (j Args) Value() (driver.Value, error) {
@@ -28,14 +38,41 @@ func (j *Args) Scan(value interface{}) error {
 	return nil
 }
 
+// Value ...
+func (e Envs) Value() (driver.Value, error) {
+	if e == nil {
+		return nil, nil
+	}
+	valueString, err := json.Marshal(e)
+	return string(valueString), err
+}
+
+// Scan ...
+func (e *Envs) Scan(value interface{}) error {
+	if err := json.Unmarshal(value.([]byte), e); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (e Envs) Clone() Envs {
+	result := make(Envs)
+	for k, v := range e {
+		result[k] = v
+	}
+	return result
+}
+
 // WorkloadRequest means workload requests
 type WorkloadRequest struct {
 	gorm.Model
+	Type        string  `gorm:"column:type;type:varchar(255)" json:"type"`
 	RestorePath *string `gorm:"column:restore_path;type:varchar(1024)" json:"restore_path"`
 	DockerImage string  `gorm:"column:docker_image;type:varchar(255);not null" json:"docker_image"`
 	Cmd         *string `gorm:"column:cmd;type:varchar(255)" json:"cmd"`
 	ArtifactDir *string `gorm:"column:artifact_dir;type:varchar(255)" json:"artifact_dir"`
 	Args        Args    `gorm:"column:args;type:varchar(1024)" json:"args"`
+	Envs        Envs    `gorm:"column:envs;type:text" json:"envs"`
 	Status      string  `gorm:"column:status;not null" json:"status"`
 	CRID        uint    `gorm:"column:cr_id;not null" json:"cr_id"`
 	RRIItemID   uint    `gorm:"column:rri_item_id;not null" json:"rri_item_id"`

--- a/pkg/cluster/manager/types/workload.go
+++ b/pkg/cluster/manager/types/workload.go
@@ -55,9 +55,12 @@ func (e *Envs) Scan(value interface{}) error {
 	return nil
 }
 
-func (e Envs) Clone() Envs {
+func (e *Envs) Clone() Envs {
 	result := make(Envs)
-	for k, v := range e {
+	if e == nil {
+		return result
+	}
+	for k, v := range *e {
 		result[k] = v
 	}
 	return result

--- a/pkg/cluster/manager/types/workload.go
+++ b/pkg/cluster/manager/types/workload.go
@@ -55,6 +55,7 @@ func (e *Envs) Scan(value interface{}) error {
 	return nil
 }
 
+// Clone ...
 func (e *Envs) Clone() Envs {
 	result := make(Envs)
 	if e == nil {

--- a/pkg/cluster/manager/util/docker.go
+++ b/pkg/cluster/manager/util/docker.go
@@ -97,6 +97,7 @@ func (d *DockerExecutor) Run(dockerImage string, envs map[string]string, cmd *st
 	return resp.ID, stdOutBuffer.Bytes(), stdErrBuffer.Bytes(), nil
 }
 
+// RmContainer rms container
 func (d *DockerExecutor) RmContainer(containerID string) error {
 	ctx := context.Background()
 	return d.Client.ContainerRemove(ctx, containerID, types.ContainerRemoveOptions{RemoveVolumes: true})

--- a/pkg/cluster/manager/util/docker.go
+++ b/pkg/cluster/manager/util/docker.go
@@ -96,3 +96,8 @@ func (d *DockerExecutor) Run(dockerImage string, envs map[string]string, cmd *st
 	}
 	return resp.ID, stdOutBuffer.Bytes(), stdErrBuffer.Bytes(), nil
 }
+
+func (d *DockerExecutor) RmContainer(containerID string) error {
+	ctx := context.Background()
+	return d.Client.ContainerRemove(ctx, containerID, types.ContainerRemoveOptions{RemoveVolumes: true})
+}

--- a/pkg/cluster/manager/workload/executor.go
+++ b/pkg/cluster/manager/workload/executor.go
@@ -19,6 +19,7 @@ func RunWorkload(
 	resources []*types.Resource,
 	rris []*types.ResourceRequestItem,
 	wr *types.WorkloadRequest,
+	artifactUUID string,
 	envs map[string]string,
 ) (dockerExecutor *util.DockerExecutor, containerID string, stdout []byte, stderr []byte, err error) {
 	id2Resource := make(map[uint]*types.Resource)
@@ -49,7 +50,7 @@ func RunWorkload(
 	envs["CLUSTER_ID"] = fmt.Sprintf("%d", cr.ID)
 	envs["CLUSTER_NAME"] = cr.Name
 	envs["API_SERVER"] = fmt.Sprintf("http://%s", util.Addr)
-	envs["ARTIFACT_URL"] = fmt.Sprintf("%s/%s", util.S3Endpoint, artifacts.ArtifactPath(cr.ID))
+	envs["ARTIFACT_URL"] = fmt.Sprintf("%s/%s/%s", util.S3Endpoint, artifacts.ArtifactDownloadPath(cr.ID), artifactUUID)
 
 	if rs, err = randomResource(component2Resources["pd"]); err != nil {
 		return nil, "", nil, nil, errors.Trace(err)

--- a/pkg/cluster/manager/workload/executor.go
+++ b/pkg/cluster/manager/workload/executor.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/juju/errors"
 
+	"github.com/pingcap/tipocket/pkg/cluster/manager/artifacts"
 	"github.com/pingcap/tipocket/pkg/cluster/manager/types"
 	"github.com/pingcap/tipocket/pkg/cluster/manager/util"
 )
@@ -48,6 +49,7 @@ func RunWorkload(
 	envs["CLUSTER_ID"] = fmt.Sprintf("%d", cr.ID)
 	envs["CLUSTER_NAME"] = cr.Name
 	envs["API_SERVER"] = fmt.Sprintf("http://%s", util.Addr)
+	envs["ARTIFACT_URL"] = fmt.Sprintf("%s/%s", util.S3Endpoint, artifacts.ArtifactPath(cr.ID))
 
 	if rs, err = randomResource(component2Resources["pd"]); err != nil {
 		return nil, "", nil, nil, errors.Trace(err)


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

### What is changed and how does it work?

This PR:

* inject artifact URL into workload containers
* Tear down when errors occurred

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
