### PR TITLE
elle: mark invalid connection in commit as unknown state

### DIFF
--- a/pkg/cluster/manager/types/resource.go
+++ b/pkg/cluster/manager/types/resource.go
@@ -2,9 +2,10 @@ package types
 
 import (
 	"fmt"
-	"github.com/jinzhu/gorm"
 	"strconv"
 	"strings"
+
+	"github.com/jinzhu/gorm"
 )
 
 const (

--- a/pkg/nemesis/container_kill.go
+++ b/pkg/nemesis/container_kill.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ngaut/log"
 	chaosv1alpha1 "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/ngaut/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/pingcap/tipocket/pkg/cluster"

--- a/pkg/nemesis/iochaos.go
+++ b/pkg/nemesis/iochaos.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ngaut/log"
 	chaosv1alpha1 "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/ngaut/log"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/pingcap/tipocket/pkg/cluster"

--- a/pkg/nemesis/kill.go
+++ b/pkg/nemesis/kill.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ngaut/log"
 	chaosv1alpha1 "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/ngaut/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/pingcap/tipocket/pkg/cluster"

--- a/pkg/nemesis/time_chaos.go
+++ b/pkg/nemesis/time_chaos.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ngaut/log"
 	chaosv1alpha1 "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/ngaut/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/pingcap/tipocket/pkg/cluster"

--- a/pkg/test-infra/scheme/scheme.go
+++ b/pkg/test-infra/scheme/scheme.go
@@ -14,8 +14,8 @@
 package scheme
 
 import (
-	astsv1alpha1 "github.com/pingcap/advanced-statefulset/pkg/client/clientset/versioned/scheme"
 	chaosoperatorv1alpha1 "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	astsv1alpha1 "github.com/pingcap/advanced-statefulset/pkg/client/clientset/versioned/scheme"
 	tidboperatorv1alpha "github.com/pingcap/tidb-operator/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/tests/list_append/append.go
+++ b/tests/list_append/append.go
@@ -174,10 +174,14 @@ func (c *client) Invoke(ctx context.Context, node cluster.ClientNode, r interfac
 	}
 
 	if err := txn.Commit(); err != nil {
+		tp := ellecore.OpTypeFail
+		if strings.Contains(err.Error(), "invalid connection") {
+			tp = ellecore.OpTypeUnknown
+		}
 		return appendResponse{
 			Result: ellecore.Op{
 				Time:  time.Now(),
-				Type:  ellecore.OpTypeFail,
+				Type:  tp,
 				Value: &mops,
 				Error: err.Error(),
 			},

--- a/tests/rw_register/register.go
+++ b/tests/rw_register/register.go
@@ -10,6 +10,7 @@ import (
 	"math/rand"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -173,10 +174,14 @@ func (c *client) Invoke(ctx context.Context, node cluster.ClientNode, r interfac
 	}
 
 	if err := txn.Commit(); err != nil {
+		tp := ellecore.OpTypeFail
+		if strings.Contains(err.Error(), "invalid connection") {
+			tp = ellecore.OpTypeUnknown
+		}
 		return registerResponse{
 			Result: ellecore.Op{
 				Time:  time.Now(),
-				Type:  ellecore.OpTypeFail,
+				Type:  tp,
 				Value: &mops,
 				Error: err.Error(),
 			},


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

There are some invalid connection errors in commit stage, but actually we don't know whether this statement is executed successful or not. Currently we mark these transactions as failed, this may wrongly result to G1a phenomenon if the transactions are successfully committed. 

### What is changed and how does it work?

If the commit error is invalid connection error, we mark this transaction to unknown state.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Side effects

 - This change may miss some real G1a phenomenon.

Related changes

 - None
