### PR TITLE
Add async commit and 1PC parameters for some cases

### DIFF
--- a/argo/cron/async-bank2.yaml
+++ b/argo/cron/async-bank2.yaml
@@ -90,3 +90,7 @@ spec:
                     value: "5000"
                   - name: tidb-failpoint
                     value: "\"github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing=1%return\""
+                  - name: async-commit
+                    default: "true"
+                  - name: one-pc
+                    default: "false"

--- a/argo/cron/async-tpcc.yaml
+++ b/argo/cron/async-tpcc.yaml
@@ -80,7 +80,7 @@ spec:
                     value: "{{workflow.parameters.repository}}"
                   - name: image-version
                     value: "{{workflow.parameters.image-version}}"
-                    - name: tidb-image
+                  - name: tidb-image
                     value: "hub.pingcap.net/qa/tidb:master-failpoint"
                   - name: tikv-image
                     value: "hub.pingcap.net/qa/tikv:master-failpoint"

--- a/argo/cron/async-tpcc.yaml
+++ b/argo/cron/async-tpcc.yaml
@@ -116,3 +116,7 @@ spec:
                     value: "/config/tidb/enable-async-commit.toml"
                   - name: tidb-failpoint
                     value: "\"github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing=2%return\""
+                  - name: async-commit
+                    default: "true"
+                  - name: one-pc
+                    default: "false"

--- a/argo/template/sc_bank2.yaml
+++ b/argo/template/sc_bank2.yaml
@@ -60,6 +60,10 @@ spec:
             default: "1000000"
           - name: tidb-failpoint
             default: "\"github.com/pingcap/tidb/server/enableTestAPI=return\""
+          - name: async-commit
+            default: "false"
+          - name: one-pc
+            default: "false"
       outputs:
         artifacts:
           - name: tidb-logs
@@ -105,4 +109,6 @@ spec:
             -matrix-sql={{inputs.parameters.matrix-sql}} \
             -concurrency={{inputs.parameters.concurrency}} \
             -accounts={{inputs.parameters.accounts}} \
-            -failpoint.tidb={{inputs.parameters.tidb-failpoint}}
+            -failpoint.tidb={{inputs.parameters.tidb-failpoint}} \
+            -async-commit={{inputs.parameters.async-commit}} \
+            -one-pc={{inputs.parameters.one-pc}}

--- a/argo/template/tpcc.yaml
+++ b/argo/template/tpcc.yaml
@@ -52,6 +52,10 @@ spec:
             default: ""
           - name: tidb-failpoint
             default: "\"github.com/pingcap/tidb/server/enableTestAPI=return\""
+          - name: async-commit
+            default: "false"
+          - name: one-pc
+            default: "false"
       outputs:
         artifacts:
           - name: tidb-logs
@@ -92,4 +96,6 @@ spec:
             -matrix-pd={{inputs.parameters.matrix-pd}} \
             -matrix-sql={{inputs.parameters.matrix-sql}} \
             -tidb-config={{inputs.parameters.tidb-config}} \
-            -failpoint.tidb={{inputs.parameters.tidb-failpoint}}
+            -failpoint.tidb={{inputs.parameters.tidb-failpoint}} \
+            -async-commit={{inputs.parameters.async-commit}} \
+            -one-pc={{inputs.parameters.one-pc}}

--- a/cmd/bank2/main.go
+++ b/cmd/bank2/main.go
@@ -45,6 +45,8 @@ var (
 	maxLength   = flag.Int("max-value-length", 128, "maximum value inserted into rocksdb")
 	replicaRead = flag.String("tidb-replica-read", "leader", "tidb_replica_read mode, support values: leader / follower / leader-and-follower, default value: leader.")
 	dbname      = flag.String("dbname", "test", "name of database to test")
+	asyncCommit = flag.Bool("async-commit", false, "whether to enable the async commit feature (default false)")
+	onePC       = flag.Bool("one-pc", false, "whether to enable the one-phase commit feature (default false)")
 )
 
 func main() {
@@ -60,21 +62,24 @@ func main() {
 	suit := util.Suit{
 		Config:   &cfg,
 		Provider: cluster.NewDefaultClusterProvider(),
-		ClientCreator: bank2.ClientCreator{Cfg: &bank2.Config{
-			NumAccounts:   *accounts,
-			Interval:      *interval,
-			TableNum:      *tables,
-			Concurrency:   *concurrency,
-			RetryLimit:    *retryLimit,
-			RunMode:       *runMode,
-			MinLength:     *minLength,
-			MaxLength:     *maxLength,
-			EnableLongTxn: *longTxn,
-			Contention:    *contention,
-			Pessimistic:   *pessimistic,
-			ReplicaRead:   *replicaRead,
-			DbName:        *dbname,
-		}},
+		ClientCreator: bank2.ClientCreator{
+			Cfg: &bank2.Config{
+				NumAccounts:   *accounts,
+				Interval:      *interval,
+				TableNum:      *tables,
+				Concurrency:   *concurrency,
+				RetryLimit:    *retryLimit,
+				RunMode:       *runMode,
+				MinLength:     *minLength,
+				MaxLength:     *maxLength,
+				EnableLongTxn: *longTxn,
+				Contention:    *contention,
+				Pessimistic:   *pessimistic,
+				ReplicaRead:   *replicaRead,
+				DbName:        *dbname,
+			},
+			AsyncCommit: *asyncCommit,
+			OnePC:       *onePC},
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
 		VerifySuit:  verify.Suit{},
 		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,

--- a/cmd/tpcc/main.go
+++ b/cmd/tpcc/main.go
@@ -36,6 +36,8 @@ var (
 	qosFile     = flag.String("qos-file", "./qos.log", "qos file")
 	checkerName = flag.String("checker", "consistency", "consistency or qos")
 	warehouses  = flag.Int("warehouses", 10, "tpcc warehouses")
+	asyncCommit = flag.Bool("async-commit", false, "whether to enable the async commit feature (default false)")
+	onePC       = flag.Bool("one-pc", false, "whether to enable the one-phase commit feature (default false)")
 )
 
 func main() {
@@ -56,6 +58,8 @@ func main() {
 			Warehouses: *warehouses,
 			Parts:      1,
 		},
+		AsyncCommit: *asyncCommit,
+		OnePC:       *onePC,
 	}
 	creator := clientCreator
 	var checker core.Checker

--- a/config/tidb/enable-async-commit.toml
+++ b/config/tidb/enable-async-commit.toml
@@ -1,2 +1,0 @@
-[tikv-client.async-commit]
-enable = true

--- a/tests/bank2/bank2.go
+++ b/tests/bank2/bank2.go
@@ -102,8 +102,8 @@ type bank2Client struct {
 	stop        int32
 	txnID       int32
 	db          *sql.DB
-	AsyncCommit bool
-	OnePC       bool
+	asyncCommit bool
+	onePC       bool
 }
 
 func (c *bank2Client) padLength(table int) int {
@@ -136,7 +136,7 @@ func (c *bank2Client) SetUp(ctx context.Context, _ []cluster.Node, clientNodes [
 	}
 	util.RandomlyChangeReplicaRead(c.String(), c.ReplicaRead, db)
 
-	if c.AsyncCommit {
+	if c.asyncCommit {
 		_, err = db.Exec("set @@global.tidb_enable_async_commit = 1;")
 	} else {
 		_, err = db.Exec("set @@global.tidb_enable_async_commit = 0;")
@@ -145,7 +145,7 @@ func (c *bank2Client) SetUp(ctx context.Context, _ []cluster.Node, clientNodes [
 		log.Fatalf("[bank2Client] set async commit failed: %v", err)
 	}
 
-	if c.OnePC {
+	if c.onePC {
 		_, err = db.Exec("set @@global.tidb_enable_1pc = 1;")
 	} else {
 		_, err = db.Exec("set @@global.tidb_enable_1pc = 0;")
@@ -460,8 +460,8 @@ func (c *bank2Client) execTransaction(db *sql.DB, from, to int, amount int) erro
 func (c ClientCreator) Create(_ cluster.ClientNode) core.Client {
 	return &bank2Client{
 		Config:      c.Cfg,
-		AsyncCommit: c.AsyncCommit,
-		OnePC:       c.OnePC,
+		asyncCommit: c.AsyncCommit,
+		onePC:       c.OnePC,
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

Since pingcap/tidb#21365, async commit needs to be enabled by setting a system variable. So we need to change some cases.

### What is changed and how does it work?

Add `async-commit` and `one-pc` parameters to the `bank2` and `tpcc` cases, and set corresponding system variables in the `SetUp`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test: manually test if these cases successfully set the system variables



Code changes

 - Has Go code change
 - Has CI related scripts change


### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
