### PR TITLE
Change default value of TiDBMonitorSvcType to NodePort.

### DIFF
--- a/pkg/test-infra/fixture/fixture.go
+++ b/pkg/test-infra/fixture/fixture.go
@@ -257,7 +257,7 @@ func init() {
 	flag.StringVar(&Context.MySQLVersion, "mysql-version", "5.6", "Default mysql version")
 	flag.StringVar(&Context.DockerRepository, "repository", "pingcap", "repo name, default is pingcap")
 	flag.StringVar(&Context.LocalVolumeStorageClass, "storage-class", "local-storage", "storage class name")
-	flag.StringVar(&Context.TiDBMonitorSvcType, "monitor-svc", "ClusterIP", "TiDB monitor service type")
+	flag.StringVar(&Context.TiDBMonitorSvcType, "monitor-svc", "NodePort", "TiDB monitor service type")
 	flag.StringVar(&Context.pprofAddr, "pprof", "0.0.0.0:8080", "Pprof address")
 	flag.DurationVar(&Context.WaitClusterReadyDuration, "wait-duration", 4*time.Hour, "clusters ready wait duration")
 


### PR DESCRIPTION
Signed-off-by: Weiwen Chen <chenweiwen@pingcap.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->
[集群监控 grafana service 类型默认使用 NodePort #332](https://github.com/pingcap/tipocket/issues/332)

### What is changed and how does it work?
Change default value of TiDBMonitorSvcType to NodePort.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has Go code change

Side effects

 - Breaking backward compatibility

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
