### PR TITLE
Support run preparation sqls for TiDB clusters

### DIFF
--- a/pkg/core/db.go
+++ b/pkg/core/db.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/pingcap/tipocket/pkg/test-infra/fixture"
 	"time"
 
 	"github.com/pingcap/tipocket/pkg/cluster"
+	"github.com/pingcap/tipocket/pkg/test-infra/fixture"
 )
 
 // DB allows to set up and tear down database.
@@ -28,7 +28,7 @@ type NoopDB struct {
 func (NoopDB) SetUp(ctx context.Context, nodes []cluster.Node, node cluster.Node) error {
 	prepareSQL := fixture.Context.TiDBClusterConfig.PrepareSQL
 	if len(prepareSQL) > 0 && node.Component == cluster.TiDB {
-		db, err := sql.Open("mysql", fmt.Sprintf("root@tcp(%s:%d)/test", node.IP, node.Port))
+		db, err := sql.Open("mysql", fmt.Sprintf("root@tcp(%s:%d)/test?multiStatements=true", node.IP, node.Port))
 		if err != nil {
 			return err
 		}

--- a/pkg/test-infra/fixture/fixture.go
+++ b/pkg/test-infra/fixture/fixture.go
@@ -125,6 +125,8 @@ type TiDBClusterConfig struct {
 	TiDBConfig string
 	TiKVConfig string
 	PDConfig   string
+	// SQLs that run after the TiDB cluster is created
+	PrepareSQL string
 
 	// replicas
 	TiDBReplicas    int
@@ -283,6 +285,7 @@ func init() {
 	flag.StringVar(&Context.TiDBClusterConfig.TiDBConfig, "tidb-config", "", "path of tidb config file (cluster A in abtest case)")
 	flag.StringVar(&Context.TiDBClusterConfig.TiKVConfig, "tikv-config", "", "path of tikv config file (cluster A in abtest case)")
 	flag.StringVar(&Context.TiDBClusterConfig.PDConfig, "pd-config", "", "path of pd config file (cluster A in abtest case)")
+	flag.StringVar(&Context.TiDBClusterConfig.PrepareSQL, "prepare-sql", "", "SQLs that run after the TiDB cluster is created (cluster A in abtest case)")
 	flag.IntVar(&Context.TiDBClusterConfig.TiDBReplicas, "tidb-replicas", 2, "number of tidb replicas")
 	flag.IntVar(&Context.TiDBClusterConfig.TiKVReplicas, "tikv-replicas", 3, "number of tikv replicas")
 	flag.IntVar(&Context.TiDBClusterConfig.PDReplicas, "pd-replicas", 3, "number of pd replicas")
@@ -292,6 +295,7 @@ func init() {
 	flag.StringVar(&Context.ABTestConfig.ClusterBConfig.TiDBConfig, "abtest.tidb-config", "", "tidb config file for cluster B")
 	flag.StringVar(&Context.ABTestConfig.ClusterBConfig.TiKVConfig, "abtest.tikv-config", "", "tikv config file for cluster B")
 	flag.StringVar(&Context.ABTestConfig.ClusterBConfig.PDConfig, "abtest.pd-config", "", "pd config file for cluster B")
+	flag.StringVar(&Context.ABTestConfig.ClusterBConfig.PrepareSQL, "abtest.prepare-sql", "", "SQLs that run after cluster B is created")
 	flag.IntVar(&Context.ABTestConfig.ClusterBConfig.TiKVReplicas, "abtest.tikv-replicas", 3, "number of tikv replicas for cluster B")
 	flag.IntVar(&Context.ABTestConfig.ClusterBConfig.TiFlashReplicas, "abtest.tiflash-replicas", 0, "number of tiflash replicas for cluster B, set 0 to disable tiflash")
 

--- a/pkg/test-infra/tidb/operation.go
+++ b/pkg/test-infra/tidb/operation.go
@@ -15,6 +15,7 @@ package tidb
 
 import (
 	"context"
+	"database/sql"
 	b64 "encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -189,6 +190,9 @@ func (o *Ops) Apply() error {
 	if err := o.waitTiDBReady(tc, fixture.Context.WaitClusterReadyDuration); err != nil {
 		return err
 	}
+	if err := o.runPreparationSQL(); err != nil {
+		return err
+	}
 	return o.applyTiDBMonitor(tm)
 }
 
@@ -243,6 +247,29 @@ func (o *Ops) waitTiDBReady(tc *v1alpha1.TidbCluster, timeout time.Duration) err
 		}
 		return true, nil
 	})
+}
+
+func (o *Ops) runPreparationSQL() error {
+	if len(o.config.PrepareSQL) > 0 {
+		clientNodes, err := o.GetClientNodes()
+		if err != nil {
+			return err
+		}
+		node := clientNodes[0]
+		db, err := sql.Open("mysql", fmt.Sprintf("root@tcp(%s:%d)/test", node.IP, node.Port))
+		if err != nil {
+			return err
+		}
+		if _, err = db.Exec(o.config.PrepareSQL); err != nil {
+			return err
+		}
+		if err = db.Close(); err != nil {
+			return err
+		}
+		// Wait until global variables take effect
+		time.Sleep(2100 * time.Millisecond)
+	}
+	return nil
 }
 
 func (o *Ops) applyTiDBMonitor(tm *v1alpha1.TidbMonitor) error {


### PR DESCRIPTION

### What is changed and how does it work?

Sometimes we need to set some global variables or do some other preparations to the TiDB cluster. With this PR, we can pass these preparation SQLs through arguments.

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
