### PR TITLE
test-infra: update the binlog support

### DIFF
--- a/pkg/test-infra/binlog/recommend.go
+++ b/pkg/test-infra/binlog/recommend.go
@@ -43,7 +43,8 @@ func newDrainer(ns, name string) *Drainer {
 			DownStreamDB: fmt.Sprintf("%s-downstream-tidb", name),
 		}
 		drainerCommandModel = DrainerCommandModel{
-			Component: drainerName,
+			Component:   drainerName,
+			ClusterName: fmt.Sprintf("%s-upstream", name),
 		}
 		configmapMountMode int32 = 420
 	)
@@ -62,7 +63,7 @@ func newDrainer(ns, name string) *Drainer {
 				Name:      drainerName,
 			},
 			Data: map[string]string{
-				"drainer-config": drainerConfigmap,
+				"config-file": drainerConfigmap,
 			},
 		},
 		&corev1.Service{
@@ -140,6 +141,12 @@ func newDrainer(ns, name string) *Drainer {
 										MountPath: "/etc/drainer",
 									},
 								},
+								Env: []corev1.EnvVar{
+									{
+										Name: "TZ",
+										Value: "UTC",
+									},
+								},
 							},
 						},
 						Volumes: []corev1.Volume{
@@ -153,7 +160,7 @@ func newDrainer(ns, name string) *Drainer {
 										DefaultMode: &configmapMountMode,
 										Items: []corev1.KeyToPath{
 											{
-												Key:  "drainer-config",
+												Key:  "config-file",
 												Path: "drainer.toml",
 											},
 										},


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

This PR updates drainer-config and startup script making it compatible with the new version of drainer.

### What is changed and how does it work?

Uses test_infra.NewBinlogCluster to create a binlog testing cluster, for example, here is the demo:

https://github.com/pingcap/tipocket/blob/ddd23d16aa31b2ba84ef1dbb336a118ad8a88c36/cmd/pocket/main.go#L49-L61

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

![image](https://user-images.githubusercontent.com/3251373/105122201-bf2e0280-5b10-11eb-93a6-e9c0fc55560a.png)

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
