### PR TITLE
Add resolve-lock in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,10 @@ pessimistic:
 	cd testcase/pessimistic; make build; \
 	cp bin/* ../../bin/
 
+resolve-lock:
+	cd testcase/resolve-lock; make build; \
+	cp bin/* ../../bin/
+
 crud:
 	$(GOBUILD) $(GOMOD) -o bin/crud cmd/crud/*.go
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

While using docker build, there is no `resolve-lock` binary in `/bin/` of image, due to `make build` doesn't generate the `resolve-lock` binary.

This flaw makes hub.pingcap.net/qa/tipocket:latest unable to run test `resolve-lock`.

Fix the makefile to generate the missing binary.

### What is changed and how does it work?

Add "resolve-lock" in makefile.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
```bash
make build
bin/resolve-lock
```
Code changes

 - Has CI related scripts change

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
