### PR TITLE
db: ignore the empty prepareSQL when set up DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VERSION   := $(if $(VERSION),$(VERSION),latest)
 PACKAGES := go list ./...| grep -vE 'vendor'
 PACKAGE_DIRECTORIES := $(PACKAGES) | sed 's|github.com/pingcap/tipocket/||'
 
-LDFLAGS += "-s -w"
+LDFLAGS += -s -w
 LDFLAGS += -X "github.com/pingcap/tipocket/pkg/test-infra/fixture.BuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "github.com/pingcap/tipocket/pkg/test-infra/fixture.BuildHash=$(shell git rev-parse HEAD)"
 

--- a/argo/cron/async-bank2.yaml
+++ b/argo/cron/async-bank2.yaml
@@ -35,6 +35,8 @@ spec:
           value: "loki"
         - name: loki-password
           value: "admin"
+        - name: prepare-sql
+          value: "set @@tidb_enable_async_commit = 1;set @@global.tidb_enable_async_commit = 1;set @@tidb_enable_1pc = 0;set @@global.tidb_enable_1pc = 0;"
     templates:
       - name: call-tipocket-scbank2
         steps:
@@ -90,7 +92,5 @@ spec:
                     value: "5000"
                   - name: tidb-failpoint
                     value: "\"github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing=1%return\""
-                  - name: async-commit
-                    default: "true"
-                  - name: one-pc
-                    default: "false"
+                  - name: prepare-sql
+                    value: "{{workflow.parameters.prepare-sql}}"

--- a/argo/cron/async-tpcc.yaml
+++ b/argo/cron/async-tpcc.yaml
@@ -53,6 +53,8 @@ spec:
           value: "mysql-system-vars.sql,tidb-system-vars.sql"
         - name: tidb-config
           value: ""
+        - name: prepare-sql
+          value: "set @@tidb_enable_async_commit = 1;set @@global.tidb_enable_async_commit = 1;set @@tidb_enable_1pc = 0;set @@global.tidb_enable_1pc = 0;"
     templates:
       - name: call-tipocket-tpcc
         steps:
@@ -116,7 +118,5 @@ spec:
                     value: "/config/tidb/enable-async-commit.toml"
                   - name: tidb-failpoint
                     value: "\"github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing=2%return\""
-                  - name: async-commit
-                    value: "true"
-                  - name: one-pc
-                    value: "false"
+                  - name: prepare-sql
+                    value: "{{workflow.parameters.prepare-sql}}"

--- a/argo/template/sc_bank2.yaml
+++ b/argo/template/sc_bank2.yaml
@@ -60,10 +60,8 @@ spec:
             default: "1000000"
           - name: tidb-failpoint
             default: "\"github.com/pingcap/tidb/server/enableTestAPI=return\""
-          - name: async-commit
-            default: "false"
-          - name: one-pc
-            default: "false"
+          - name: prepare-sql
+            default: ""
       outputs:
         artifacts:
           - name: tidb-logs
@@ -110,5 +108,5 @@ spec:
             -concurrency={{inputs.parameters.concurrency}} \
             -accounts={{inputs.parameters.accounts}} \
             -failpoint.tidb={{inputs.parameters.tidb-failpoint}} \
-            -async-commit={{inputs.parameters.async-commit}} \
-            -one-pc={{inputs.parameters.one-pc}}
+            -prepare-sql="{{inputs.parameters.prepare-sql}}"
+

--- a/argo/template/tpcc.yaml
+++ b/argo/template/tpcc.yaml
@@ -52,10 +52,8 @@ spec:
             default: ""
           - name: tidb-failpoint
             default: "\"github.com/pingcap/tidb/server/enableTestAPI=return\""
-          - name: async-commit
-            default: "false"
-          - name: one-pc
-            default: "false"
+          - name: prepare-sql
+            default: ""
       outputs:
         artifacts:
           - name: tidb-logs
@@ -97,5 +95,4 @@ spec:
             -matrix-sql={{inputs.parameters.matrix-sql}} \
             -tidb-config={{inputs.parameters.tidb-config}} \
             -failpoint.tidb={{inputs.parameters.tidb-failpoint}} \
-            -async-commit={{inputs.parameters.async-commit}} \
-            -one-pc={{inputs.parameters.one-pc}}
+            -prepare-sql="{{inputs.parameters.prepare-sql}}"

--- a/cmd/bank2/main.go
+++ b/cmd/bank2/main.go
@@ -45,8 +45,6 @@ var (
 	maxLength   = flag.Int("max-value-length", 128, "maximum value inserted into rocksdb")
 	replicaRead = flag.String("tidb-replica-read", "leader", "tidb_replica_read mode, support values: leader / follower / leader-and-follower, default value: leader.")
 	dbname      = flag.String("dbname", "test", "name of database to test")
-	asyncCommit = flag.Bool("async-commit", false, "whether to enable the async commit feature (default false)")
-	onePC       = flag.Bool("one-pc", false, "whether to enable the one-phase commit feature (default false)")
 )
 
 func main() {
@@ -78,8 +76,7 @@ func main() {
 				ReplicaRead:   *replicaRead,
 				DbName:        *dbname,
 			},
-			AsyncCommit: *asyncCommit,
-			OnePC:       *onePC},
+		},
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
 		VerifySuit:  verify.Suit{},
 		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,

--- a/cmd/tpcc/main.go
+++ b/cmd/tpcc/main.go
@@ -36,8 +36,6 @@ var (
 	qosFile     = flag.String("qos-file", "./qos.log", "qos file")
 	checkerName = flag.String("checker", "consistency", "consistency or qos")
 	warehouses  = flag.Int("warehouses", 10, "tpcc warehouses")
-	asyncCommit = flag.Bool("async-commit", false, "whether to enable the async commit feature (default false)")
-	onePC       = flag.Bool("one-pc", false, "whether to enable the one-phase commit feature (default false)")
 )
 
 func main() {
@@ -58,8 +56,6 @@ func main() {
 			Warehouses: *warehouses,
 			Parts:      1,
 		},
-		AsyncCommit: *asyncCommit,
-		OnePC:       *onePC,
 	}
 	creator := clientCreator
 	var checker core.Checker

--- a/pkg/core/db.go
+++ b/pkg/core/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pingcap/tipocket/pkg/cluster"
@@ -27,7 +28,7 @@ type NoopDB struct {
 // SetUp initializes the database.
 func (NoopDB) SetUp(ctx context.Context, nodes []cluster.Node, node cluster.Node) error {
 	// pre-set global variables
-	if len(fixture.Context.TiDBClusterConfig.PrepareSQL) == 0 {
+	if len(strings.TrimSpace(fixture.Context.TiDBClusterConfig.PrepareSQL)) == 0 {
 		return nil
 	}
 	isFirstTiDB := false

--- a/pkg/core/db.go
+++ b/pkg/core/db.go
@@ -26,6 +26,10 @@ type NoopDB struct {
 
 // SetUp initializes the database.
 func (NoopDB) SetUp(ctx context.Context, nodes []cluster.Node, node cluster.Node) error {
+	// pre-set global variables
+	if len(fixture.Context.TiDBClusterConfig.PrepareSQL) == 0 {
+		return nil
+	}
 	isFirstTiDB := false
 	for _, n := range nodes {
 		if n.Component == cluster.TiDB {

--- a/testcase/ondup/Makefile
+++ b/testcase/ondup/Makefile
@@ -5,7 +5,7 @@ VERSION   := $(if $(VERSION),$(VERSION),latest)
 
 PACKAGES := go list ./...| grep -vE 'vendor'
 
-LDFLAGS += "-s -w"
+LDFLAGS += -s -w
 LDFLAGS += -X "github.com/pingcap/tipocket/pkg/test-infra/fixture.BuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "github.com/pingcap/tipocket/pkg/test-infra/fixture.BuildHash=$(shell git rev-parse HEAD)"
 

--- a/testcase/rawkv-linearizability/Makefile
+++ b/testcase/rawkv-linearizability/Makefile
@@ -5,7 +5,7 @@ VERSION   := $(if $(VERSION),$(VERSION),latest)
 
 PACKAGES := go list ./...| grep -vE 'vendor'
 
-LDFLAGS += "-s -w"
+LDFLAGS += -s -w
 LDFLAGS += -X "github.com/pingcap/tipocket/pkg/test-infra/fixture.BuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "github.com/pingcap/tipocket/pkg/test-infra/fixture.BuildHash=$(shell git rev-parse HEAD)"
 

--- a/testcase/resolve-lock/Makefile
+++ b/testcase/resolve-lock/Makefile
@@ -5,7 +5,7 @@ VERSION   := $(if $(VERSION),$(VERSION),latest)
 
 PACKAGES := go list ./...| grep -vE 'vendor'
 
-LDFLAGS += "-s -w"
+LDFLAGS += -s -w
 LDFLAGS += -X "github.com/pingcap/tipocket/pkg/test-infra/fixture.BuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "github.com/pingcap/tipocket/pkg/test-infra/fixture.BuildHash=$(shell git rev-parse HEAD)"
 

--- a/testcase/sqllogictest/Makefile
+++ b/testcase/sqllogictest/Makefile
@@ -5,7 +5,7 @@ VERSION   := $(if $(VERSION),$(VERSION),latest)
 
 PACKAGES := go list ./...| grep -vE 'vendor'
 
-LDFLAGS += "-s -w"
+LDFLAGS += -s -w
 LDFLAGS += -X "github.com/pingcap/tipocket/pkg/test-infra/fixture.BuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "github.com/pingcap/tipocket/pkg/test-infra/fixture.BuildHash=$(shell git rev-parse HEAD)"
 

--- a/testcase/titan/Makefile
+++ b/testcase/titan/Makefile
@@ -5,7 +5,7 @@ VERSION   := $(if $(VERSION),$(VERSION),latest)
 
 PACKAGES := go list ./...| grep -vE 'vendor'
 
-LDFLAGS += "-s -w"
+LDFLAGS += -s -w
 LDFLAGS += -X "github.com/pingcap/tipocket/pkg/test-infra/fixture.BuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "github.com/pingcap/tipocket/pkg/test-infra/fixture.BuildHash=$(shell git rev-parse HEAD)"
 

--- a/tests/bank2/bank2.go
+++ b/tests/bank2/bank2.go
@@ -91,19 +91,15 @@ type Config struct {
 
 // ClientCreator ...
 type ClientCreator struct {
-	Cfg         *Config
-	AsyncCommit bool
-	OnePC       bool
+	Cfg *Config
 }
 
 type bank2Client struct {
 	*Config
-	wg          sync.WaitGroup
-	stop        int32
-	txnID       int32
-	db          *sql.DB
-	asyncCommit bool
-	onePC       bool
+	wg    sync.WaitGroup
+	stop  int32
+	txnID int32
+	db    *sql.DB
 }
 
 func (c *bank2Client) padLength(table int) int {
@@ -135,24 +131,6 @@ func (c *bank2Client) SetUp(ctx context.Context, _ []cluster.Node, clientNodes [
 		log.Fatalf("[bank2Client] create db client error %v", err)
 	}
 	util.RandomlyChangeReplicaRead(c.String(), c.ReplicaRead, db)
-
-	if c.asyncCommit {
-		_, err = db.Exec("set @@global.tidb_enable_async_commit = 1;")
-	} else {
-		_, err = db.Exec("set @@global.tidb_enable_async_commit = 0;")
-	}
-	if err != nil {
-		log.Fatalf("[bank2Client] set async commit failed: %v", err)
-	}
-
-	if c.onePC {
-		_, err = db.Exec("set @@global.tidb_enable_1pc = 1;")
-	} else {
-		_, err = db.Exec("set @@global.tidb_enable_1pc = 0;")
-	}
-	if err != nil {
-		log.Fatalf("[bank2Client] set 1PC failed: %v", err)
-	}
 
 	_, err = db.Exec("set @@global.tidb_txn_mode = 'pessimistic';")
 	if err != nil {
@@ -446,9 +424,7 @@ func (c *bank2Client) execTransaction(db *sql.DB, from, to int, amount int) erro
 // Create ...
 func (c ClientCreator) Create(_ cluster.ClientNode) core.Client {
 	return &bank2Client{
-		Config:      c.Cfg,
-		asyncCommit: c.AsyncCommit,
-		onePC:       c.OnePC,
+		Config: c.Cfg,
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

I don't know why TiDB is blocked on empty exec statements: https://github.com/pingcap/tidb/issues/22646

```
2021/02/01 04:09:12 suit.go:87: [info] deploy cluster success, node:[tipocket-rw-register-v4011-pre-pd-0 172.18.42.40:2379 tipocket-rw-register-v4011-pre-pd-1 172.18.240.163:2379
tipocket-rw-register-v4011-pre-pd-2 172.18.180.156:2379 tipocket-rw-register-v4011-pre-tidb-0 172.18.201.168:4000 tipocket-rw-register-v4011-pre-tidb-1 172.18.42.56:4000 tipocket-
rw-register-v4011-pre-tikv-0 172.18.108.204:20160 tipocket-rw-register-v4011-pre-tikv-1 172.18.201.145:20160 tipocket-rw-register-v4011-pre-tikv-2 172.18.49.16:20160 tipocket-rw-r
egister-v4011-pre-tikv-3 172.18.172.100:20160], client node:[tipocket-rw-register-v4011-pre 172.16.4.72:31768]
2021/02/01 04:09:12 control.go:98: [info] start controller with &{Mode:On Schedule mode DB: Nodes:[tipocket-rw-register-v4011-pre-pd-0 172.18.42.40:2379 tipocket-rw-register-v4011
-pre-pd-1 172.18.240.163:2379 tipocket-rw-register-v4011-pre-pd-2 172.18.180.156:2379 tipocket-rw-register-v4011-pre-tidb-0 172.18.201.168:4000 tipocket-rw-register-v4011-pre-tidb
-1 172.18.42.56:4000 tipocket-rw-register-v4011-pre-tikv-0 172.18.108.204:20160 tipocket-rw-register-v4011-pre-tikv-1 172.18.201.145:20160 tipocket-rw-register-v4011-pre-tikv-2 17
2.18.49.16:20160 tipocket-rw-register-v4011-pre-tikv-3 172.18.172.100:20160] ClientNodes:[tipocket-rw-register-v4011-pre 172.16.4.72:31768 tipocket-rw-register-v4011-pre 172.16.4.
72:31768 tipocket-rw-register-v4011-pre 172.16.4.72:31768 tipocket-rw-register-v4011-pre 172.16.4.72:31768 tipocket-rw-register-v4011-pre 172.16.4.72:31768] ClientCount:5 ChaosNam
espace: RunRound:10 RunTime:1h40m0s RequestCount:100000 History:./history.log ClientConfig:<nil>}
2021/02/01 04:09:12 control.go:347: [info] begin to set up database
2021/02/01 04:09:12 control.go:349: [info] begin to set up database on tipocket-rw-register-v4011-pre-tikv-3 172.18.172.100:20160
2021/02/01 04:09:12 control.go:349: [info] begin to set up database on tipocket-rw-register-v4011-pre-tikv-0 172.18.108.204:20160
2021/02/01 04:09:12 control.go:349: [info] begin to set up database on tipocket-rw-register-v4011-pre-pd-2 172.18.180.156:2379
2021/02/01 04:09:12 control.go:349: [info] begin to set up database on tipocket-rw-register-v4011-pre-tikv-1 172.18.201.145:20160
2021/02/01 04:09:12 control.go:349: [info] begin to set up database on tipocket-rw-register-v4011-pre-tikv-2 172.18.49.16:20160
2021/02/01 04:09:12 control.go:349: [info] begin to set up database on tipocket-rw-register-v4011-pre-pd-0 172.18.42.40:2379
2021/02/01 04:09:12 control.go:349: [info] begin to set up database on tipocket-rw-register-v4011-pre-tidb-0 172.18.201.168:4000
2021/02/01 04:09:12 control.go:349: [info] begin to set up database on tipocket-rw-register-v4011-pre-tidb-1 172.18.42.56:4000
2021/02/01 04:09:12 control.go:349: [info] begin to set up database on tipocket-rw-register-v4011-pre-pd-1 172.18.240.163:2379
```

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
