### PR TITLE
tests/vbank: fix some bugs

### DIFF
--- a/cmd/vbank/main.go
+++ b/cmd/vbank/main.go
@@ -29,6 +29,8 @@ import (
 )
 
 var (
+	clusterName = flag.String("cluster-name", "", "tidb cluster name (default to namespace)")
+
 	pkType        = flag.String("pk_type", "int", "primary key type, int,decimal,string")
 	partition     = flag.Bool("partition", true, "use partitioned table")
 	useRange      = flag.Bool("range", false, "use range condition")
@@ -38,6 +40,9 @@ var (
 
 func main() {
 	flag.Parse()
+	if len(*clusterName) == 0 {
+		*clusterName = fixture.Context.Namespace
+	}
 	cfg := control.Config{
 		Mode:         control.ModeOnSchedule,
 		ClientCount:  fixture.Context.ClientCount,
@@ -65,7 +70,7 @@ func main() {
 		VerifySuit:       verifySuit,
 		Provider:         cluster.NewDefaultClusterProvider(),
 		NemesisGens:      util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs:      test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace, fixture.Context.TiDBClusterConfig),
+		ClusterDefs:      test_infra.NewDefaultCluster(fixture.Context.Namespace, *clusterName, fixture.Context.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())
 }

--- a/run/lib/case.libsonnet
+++ b/run/lib/case.libsonnet
@@ -56,9 +56,10 @@
     [
       '/bin/txn-rand-pessimistic',
     ],
-  vbank(args={})::
+  vbank(args={ clusterName: 'vbank' })::
     [
       '/bin/vbank',
+      '-cluster-name=%s' % args.clusterName,
     ],
   'example'(args={})::
     [

--- a/run/workflow/vbank.jsonnet
+++ b/run/workflow/vbank.jsonnet
@@ -7,6 +7,6 @@
       // 'storage-class': 'local-storage',
       'tikv-replicas': '4',
     },
-    command: {},
+    command: { clusterName: 'vbank' },
   },
 }

--- a/tests/vbank/v_bank.go
+++ b/tests/vbank/v_bank.go
@@ -48,6 +48,8 @@ const (
 	vbCreateInitialBalance = 10
 )
 
+func (c *Client) multiTable() bool { return !c.cfg.Partition }
+
 func (c *Client) genCreateTableSQL(i int) string {
 	var pkType string
 	switch c.cfg.PKType {
@@ -79,7 +81,7 @@ func (c *Client) genCreateTableSQL(i int) string {
 
 func (c *Client) genInitialInsertSQL(id int) string {
 	rowID := id
-	if !c.cfg.Partition {
+	if c.multiTable() {
 		rowID = 0
 	}
 	return fmt.Sprintf("insert into %s (id, balance, created_at) VALUES (%s, %d, '%.19s')",
@@ -152,7 +154,7 @@ func (c *Client) SetUp(ctx context.Context, _ []cluster.Node, clientNodes []clus
 	}
 	c.dropTables(ctx)
 	tblCnt := vbAccountNum
-	if c.cfg.Partition {
+	if !c.multiTable() {
 		tblCnt = 1
 	}
 	_, err = db.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS v_bank_txn_status (ts BIGINT UNSIGNED PRIMARY KEY)")
@@ -182,12 +184,12 @@ func (c *Client) TearDown(ctx context.Context, nodes []cluster.ClientNode, idx i
 }
 
 func (c *Client) dropTables(ctx context.Context) {
-	if c.cfg.Partition {
-		c.db.ExecContext(ctx, "drop table if exists v_bank")
-	} else {
+	if c.multiTable() {
 		for i := 0; i < vbAccountNum; i++ {
 			c.db.ExecContext(ctx, "drop table if exists "+c.getTableName(i))
 		}
+	} else {
+		c.db.ExecContext(ctx, "drop table if exists v_bank")
 	}
 	c.db.ExecContext(ctx, "DROP TABLE IF EXISTS v_bank_txn_status")
 }
@@ -312,14 +314,14 @@ func (c *Client) checkTxnStatus(ctx context.Context, ts uint64) (committed bool)
 }
 
 func (c *Client) getTableName(accID int) string {
-	if c.cfg.Partition {
-		return "v_bank"
+	if c.multiTable() {
+		return "v_bank_" + strconv.Itoa(accID)
 	}
-	return "v_bank_" + strconv.Itoa(accID)
+	return "v_bank"
 }
 
 func (c *Client) getWhereClause(accID int) string {
-	if c.cfg.Partition {
+	if !c.multiTable() {
 		if c.cfg.Range {
 			return fmt.Sprintf("id > %s and id < %s", c.idValue(accID-1), c.idValue(accID+1))
 		}
@@ -332,6 +334,9 @@ func (c *Client) getWhereClause(accID int) string {
 }
 
 func (c *Client) idValue(id int) string {
+	if c.multiTable() {
+		id = 0
+	}
 	if c.cfg.PKType == PKTypeString {
 		return fmt.Sprintf("'%d'", id)
 	}
@@ -356,6 +361,9 @@ func (bs *BankState) equal(bs2 *BankState) bool {
 }
 
 func (bs *BankState) transfer(from, to int, amount float64) {
+	if from == to {
+		return
+	}
 	for i := range bs.Accounts {
 		acc := &bs.Accounts[i]
 		if acc.ID == from {
@@ -426,7 +434,7 @@ func (bs *BankState) append(id int, balance float64) {
 }
 
 func (c *Client) invokeRead(ctx context.Context) (*BankState, error) {
-	if !c.cfg.Partition {
+	if c.multiTable() {
 		return c.invokeReadMultiTable(ctx)
 	}
 	return c.invokeReadSingleTable(ctx)
@@ -638,6 +646,7 @@ func (c *Client) invokeDeleteAccount(ctx context.Context) (res *DeleteResult, er
 	}
 	deleteStmt := fmt.Sprintf("DELETE FROM %s WHERE %s", c.getTableName(res.VictimID), c.getWhereClause(res.VictimID))
 	_, err = c.tx.ExecContext(ctx, deleteStmt)
+	// fmt.Printf(">> delete account %q -> %v\n", deleteStmt, err)
 	if err != nil {
 		return
 	}
@@ -667,6 +676,7 @@ func (c *Client) invokeCreateAccount(ctx context.Context) (resp *CreateResult, e
 	insertStmt := fmt.Sprintf("INSERT INTO %s (id, balance) VALUES (%s, %d)",
 		c.getTableName(resp.NewID), c.idValue(resp.NewID), vbCreateInitialBalance)
 	_, err = c.tx.ExecContext(ctx, insertStmt)
+	// fmt.Printf(">> create account %q -> %v\n", insertStmt, err)
 	if err != nil {
 		return
 	}

--- a/tests/vbank/v_bank.go
+++ b/tests/vbank/v_bank.go
@@ -646,7 +646,6 @@ func (c *Client) invokeDeleteAccount(ctx context.Context) (res *DeleteResult, er
 	}
 	deleteStmt := fmt.Sprintf("DELETE FROM %s WHERE %s", c.getTableName(res.VictimID), c.getWhereClause(res.VictimID))
 	_, err = c.tx.ExecContext(ctx, deleteStmt)
-	// fmt.Printf(">> delete account %q -> %v\n", deleteStmt, err)
 	if err != nil {
 		return
 	}
@@ -676,7 +675,6 @@ func (c *Client) invokeCreateAccount(ctx context.Context) (resp *CreateResult, e
 	insertStmt := fmt.Sprintf("INSERT INTO %s (id, balance) VALUES (%s, %d)",
 		c.getTableName(resp.NewID), c.idValue(resp.NewID), vbCreateInitialBalance)
 	_, err = c.tx.ExecContext(ctx, insertStmt)
-	// fmt.Printf(">> create account %q -> %v\n", insertStmt, err)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

1. `Client.idValue` should always return 0 when in multi-table mode.
2. Since `from` can be equal to `to` in vbank, `BankState.transfer` didn't handle it correctly.

### What is changed and how does it work?

Fix above issues, also allow specifying cluster name by command flag.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
