### PR TITLE
tests/vbank: add a flag to set conn params

### DIFF
--- a/cmd/vbank/main.go
+++ b/cmd/vbank/main.go
@@ -36,6 +36,7 @@ var (
 	useRange      = flag.Bool("range", false, "use range condition")
 	updateInPlace = flag.Bool("update_in_place", false, "use update in place mode")
 	readCommitted = flag.Bool("read_committed", false, "use READ-COMMITTED isolation level")
+	connParams    = flag.String("conn_params", "", "connection parameters")
 )
 
 func main() {
@@ -62,6 +63,7 @@ func main() {
 		Range:         *useRange,
 		ReadCommitted: *readCommitted,
 		UpdateInPlace: *updateInPlace,
+		ConnParams:    *connParams,
 	}
 	suit := util.Suit{
 		Config:           &cfg,

--- a/run/lib/case.libsonnet
+++ b/run/lib/case.libsonnet
@@ -56,10 +56,11 @@
     [
       '/bin/txn-rand-pessimistic',
     ],
-  vbank(args={ clusterName: 'vbank' })::
+  vbank(args={ clusterName: 'vbank', connParams: '' })::
     [
       '/bin/vbank',
       '-cluster-name=%s' % args.clusterName,
+      '-conn_params=%s' % args.connParams,
     ],
   crossregion(args={ tso_request_count: '2000' })::
     [

--- a/run/workflow/vbank.jsonnet
+++ b/run/workflow/vbank.jsonnet
@@ -7,6 +7,6 @@
       // 'storage-class': 'local-storage',
       'tikv-replicas': '4',
     },
-    command: { clusterName: 'vbank' },
+    command: { clusterName: 'vbank', connParams: '' },
   },
 }

--- a/tests/vbank/v_bank.go
+++ b/tests/vbank/v_bank.go
@@ -40,6 +40,8 @@ type Config struct {
 	// When UpdateInPlace is set to true, we update with `set balance = balance - @amount`, otherwise we select for update first,
 	// Then update by `set balance = @new_balance`.
 	UpdateInPlace bool
+	// ConnParams are parameters passed to the mysql-driver, see https://github.com/go-sql-driver/mysql#parameters .
+	ConnParams string
 }
 
 const (
@@ -144,7 +146,11 @@ func (c *Client) SetUp(ctx context.Context, _ []cluster.Node, clientNodes []clus
 	c.idx = idx
 	c.r = rand.New(rand.NewSource(time.Now().UnixNano()))
 	node := clientNodes[idx]
-	db, err := sql.Open("mysql", fmt.Sprintf("root@tcp(%s:%d)/test", node.IP, node.Port))
+	dsn := fmt.Sprintf("root@tcp(%s:%d)/test", node.IP, node.Port)
+	if len(c.cfg.ConnParams) > 0 {
+		dsn = dsn + "?" + c.cfg.ConnParams
+	}
+	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Cannot specify connection parameters currently.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Add a flag to allow us set connection parameters so that we can enable some new features (like async-commit, clustered index) by system variables, (eg. `-conn_params='tidb_enable_async_commit=1&tidb_enable_1pc=1'`)

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Side effects

 - None

Related changes

 - None

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
