### PR TITLE
tests/vbank: fix unexpected error returned by invokeReadMultiTable

### DIFF
--- a/tests/vbank/v_bank.go
+++ b/tests/vbank/v_bank.go
@@ -452,6 +452,7 @@ func (c *Client) invokeReadMultiTable(ctx context.Context) (result *BankState, e
 		var balance float64
 		err = c.tx.QueryRowContext(ctx, "select balance from "+c.getTableName(i)).Scan(&balance)
 		if err == sql.ErrNoRows {
+			err = nil
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

When vbank try to dump state in multi-table mode, there is a chance that the function will return ErrNoRows unexpectly, which causes the test failed with `[fatal] dump state failed, timed out waiting for the condition`.

### What is changed and how does it work?

Avoid ErrNoRows returned accidentally.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Side effects

 - None

Related changes

 - None

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
