### PR TITLE
cdc: replace deployment with tidb-operator and update monitor-initializer

### DIFF
--- a/cmd/cdc-bank/main.go
+++ b/cmd/cdc-bank/main.go
@@ -28,8 +28,9 @@ import (
 )
 
 var (
-	accounts    = flag.Int("accounts", 50, "the number of accounts")
-	concurrency = flag.Int("concurrency", 32, "concurrency worker count")
+	accounts      = flag.Int("accounts", 50, "the number of accounts")
+	concurrency   = flag.Int("concurrency", 32, "concurrency worker count")
+	ticdcReplicas = flag.Int("ticdc-replicas", 1, "the ticdc replicas")
 )
 
 func main() {
@@ -51,6 +52,7 @@ func main() {
 	// Only set failpoints in the upstream
 	downstreamCfg := c.TiDBClusterConfig
 	downstreamCfg.TiDBFailPoint = ""
+	c.TiDBClusterConfig.TiCDCReplicas = *ticdcReplicas
 	suit := util.Suit{
 		Config:   &cfg,
 		Provider: cluster.NewDefaultClusterProvider(),

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -22,8 +22,8 @@ const (
 	Pump Component = "pump"
 	// Drainer Component identifier
 	Drainer Component = "drainer"
-	// CDC Component identifier
-	CDC Component = "cdc"
+	// TiCDC Component identifier
+	TiCDC Component = "ticdc"
 	// DM Component identifier
 	DM Component = "dm"
 	// Monitor Component identifier

--- a/pkg/test-infra/clusters.go
+++ b/pkg/test-infra/clusters.go
@@ -152,7 +152,7 @@ func NewCDCCluster(namespace, name string, upstreamConfig, downstreamConfig fixt
 			tidb.New(namespace, name+"-upstream", upstreamConfig),
 			tidb.New(namespace, name+"-downstream", downstreamConfig),
 		),
-		cdc.New(namespace, name),
+		cdc.New(namespace, name, name+"-upstream", name+"-downstream"),
 	)
 }
 
@@ -217,7 +217,7 @@ func NewTiFlashCDCABTestCluster(namespace, name string, confA, confB fixture.TiD
 			NewTiFlashCluster(namespace, name+"-upstream", confA),
 			tidb.New(namespace, name+"-downstream", confB),
 		),
-		cdc.New(namespace, name),
+		cdc.New(namespace, name, name+"-upstream", name+"-downstream"),
 	)
 }
 

--- a/pkg/test-infra/fixture/cdc.go
+++ b/pkg/test-infra/fixture/cdc.go
@@ -15,11 +15,8 @@ package fixture
 
 // CDCConfig for binlog component
 type CDCConfig struct {
-	Image              string
 	EnableKafka        bool
 	KafkaConsumerImage string
-	LogLevel           string
-	Timezone           string
 	SortEngine         string
 	SortDir            string
 }

--- a/pkg/test-infra/fixture/cdc.go
+++ b/pkg/test-infra/fixture/cdc.go
@@ -17,6 +17,9 @@ package fixture
 type CDCConfig struct {
 	EnableKafka        bool
 	KafkaConsumerImage string
+	LogLevel           string
+	Timezone           string
 	SortEngine         string
 	SortDir            string
+	LogFile            string
 }

--- a/pkg/test-infra/fixture/fixture.go
+++ b/pkg/test-infra/fixture/fixture.go
@@ -317,8 +317,11 @@ func init() {
 
 	flag.BoolVar(&Context.CDCConfig.EnableKafka, "cdc.enable-kafka", false, "enable kafka sink")
 	flag.StringVar(&Context.CDCConfig.KafkaConsumerImage, "cdc.kafka-consumer-image", "docker.io/pingcap/ticdc-kafka:nightly", "the kafka consumer image to use when kafka is enabled")
+	flag.StringVar(&Context.CDCConfig.LogLevel, "cdc.log-level", "debug", "log level for cdc test, default debug")
+	flag.StringVar(&Context.CDCConfig.Timezone, "cdc.timezone", "UTC", "timezone of cdc cluster, default UTC")
 	flag.StringVar(&Context.CDCConfig.SortEngine, "cdc.sort-engine", "memory", "sort engine")
-	flag.StringVar(&Context.CDCConfig.SortDir, "cdc.sort-dir", "/tmp/sort_cache", "file sort dir")
+	flag.StringVar(&Context.CDCConfig.SortDir, "cdc.sort-dir", "/tmp/cdc/sort_cache", "file sort dir")
+	flag.StringVar(&Context.CDCConfig.LogFile, "cdc.log-file", "/tmp/cdc/cdc.log", "cdc log file")
 
 	flag.StringVar(&Context.DMConfig.MySQLConf.Version, "dm.mysql.version", "5.7", "MySQL version used in DM-pocket")
 	flag.StringVar(&Context.DMConfig.MySQLConf.StorageSize, "dm.mysql.storage-size", "10Gi", "request storage size for MySQL")

--- a/pkg/test-infra/fixture/fixture.go
+++ b/pkg/test-infra/fixture/fixture.go
@@ -122,6 +122,7 @@ type TiDBClusterConfig struct {
 	TiKVImage    string
 	PDImage      string
 	TiFlashImage string
+	TiCDCImage   string
 
 	// configurations
 	TiDBConfig string
@@ -135,6 +136,7 @@ type TiDBClusterConfig struct {
 	TiKVReplicas    int
 	PDReplicas      int
 	TiFlashReplicas int
+	TiCDCReplicas   int
 
 	// Database address
 	TiDBAddr addressArrayFlags
@@ -288,6 +290,7 @@ func init() {
 	flag.StringVar(&Context.TiDBClusterConfig.TiKVImage, "tikv-image", "", "tikv image")
 	flag.StringVar(&Context.TiDBClusterConfig.PDImage, "pd-image", "", "pd image")
 	flag.StringVar(&Context.TiDBClusterConfig.TiFlashImage, "tiflash-image", "", "tiflash image")
+	flag.StringVar(&Context.TiDBClusterConfig.TiCDCImage, "ticdc-image", "", "cdc image")
 
 	flag.StringVar(&Context.TiDBClusterConfig.TiDBConfig, "tidb-config", "", "path of tidb config file (cluster A in abtest case)")
 	flag.StringVar(&Context.TiDBClusterConfig.TiKVConfig, "tikv-config", "", "path of tikv config file (cluster A in abtest case)")
@@ -312,11 +315,8 @@ func init() {
 	flag.IntVar(&Context.ABTestConfig.Concurrency, "abtest.concurrency", 3, "test concurrency, parallel session number")
 	flag.BoolVar(&Context.ABTestConfig.GeneralLog, "abtest.general-log", false, "enable general log in TiDB")
 
-	flag.StringVar(&Context.CDCConfig.Image, "cdc.version", "", `overwrite "-image-version" flag for CDC`)
 	flag.BoolVar(&Context.CDCConfig.EnableKafka, "cdc.enable-kafka", false, "enable kafka sink")
 	flag.StringVar(&Context.CDCConfig.KafkaConsumerImage, "cdc.kafka-consumer-image", "docker.io/pingcap/ticdc-kafka:nightly", "the kafka consumer image to use when kafka is enabled")
-	flag.StringVar(&Context.CDCConfig.LogLevel, "cdc.log-level", "debug", "log level for cdc test, default debug")
-	flag.StringVar(&Context.CDCConfig.Timezone, "cdc.timezone", "UTC", "timezone of cdc cluster, default UTC")
 	flag.StringVar(&Context.CDCConfig.SortEngine, "cdc.sort-engine", "memory", "sort engine")
 	flag.StringVar(&Context.CDCConfig.SortDir, "cdc.sort-dir", "/tmp/sort_cache", "file sort dir")
 

--- a/pkg/test-infra/tidb/operation.go
+++ b/pkg/test-infra/tidb/operation.go
@@ -587,7 +587,7 @@ func (o *Ops) parseNodeFromPodList(pods *corev1.PodList) ([]cluster.Node, error)
 		var podIP = pod.Status.PodIP
 		// because all tidb components are managed by statefulset with a related -peer headless service
 		// we use the fqdn as the the node ip
-		if component == "tikv" || component == "tidb" || component == "pd" || component == "tiflash" {
+		if component == "tikv" || component == "tidb" || component == "pd" || component == "tiflash" || component == "ticdc" {
 			var err error
 			podIP, err = util.GetFQDNFromStsPod(&pod)
 			if err != nil {

--- a/pkg/test-infra/tidb/recommend.go
+++ b/pkg/test-infra/tidb/recommend.go
@@ -15,6 +15,7 @@ package tidb
 
 import (
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -209,6 +210,22 @@ func RecommendedTiDBCluster(ns, name string, clusterConfig fixture.TiDBClusterCo
 							Name:        "log",
 							StorageSize: "200Gi",
 							MountPath:   "/var/log/tidblog",
+						},
+					},
+				},
+				TiCDC: &v1alpha1.TiCDCSpec{
+					Replicas: int32(clusterConfig.TiCDCReplicas),
+					ComponentSpec: v1alpha1.ComponentSpec{
+						Image: util.BuildImage("ticdc", clusterConfig.ImageVersion, clusterConfig.TiCDCImage),
+					},
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							fixture.CPU:    resource.MustParse("1000m"),
+							fixture.Memory: resource.MustParse("1Gi"),
+						},
+						Limits: corev1.ResourceList{
+							fixture.CPU:    resource.MustParse("1000m"),
+							fixture.Memory: resource.MustParse("8Gi"),
 						},
 					},
 				},

--- a/pkg/test-infra/tidb/recommend.go
+++ b/pkg/test-infra/tidb/recommend.go
@@ -267,7 +267,7 @@ func RecommendedTiDBCluster(ns, name string, clusterConfig fixture.TiDBClusterCo
 				Initializer: v1alpha1.InitializerSpec{
 					MonitorContainer: v1alpha1.MonitorContainer{
 						BaseImage: "pingcap/tidb-monitor-initializer",
-						Version:   "v4.0.9",
+						Version:   "nightly",
 					},
 				},
 				Reloader: v1alpha1.ReloaderSpec{

--- a/pkg/test-infra/tidb/recommend.go
+++ b/pkg/test-infra/tidb/recommend.go
@@ -228,6 +228,12 @@ func RecommendedTiDBCluster(ns, name string, clusterConfig fixture.TiDBClusterCo
 							fixture.Memory: resource.MustParse("8Gi"),
 						},
 					},
+					Config: &v1alpha1.TiCDCConfig{
+						Timezone: &fixture.Context.CDCConfig.Timezone,
+						LogLevel: &fixture.Context.CDCConfig.LogLevel,
+						// FIXME(@mahjonp): tidb-operator haven't supported StorageVolume claims now.
+						LogFile: &fixture.Context.CDCConfig.LogFile,
+					},
 				},
 			},
 		},

--- a/pkg/test-infra/util/util.go
+++ b/pkg/test-infra/util/util.go
@@ -57,6 +57,8 @@ func FindPort(podName, component string, containers []corev1.Container) int32 {
 		priorityPort = 8261
 	} else if component == string(cluster.MySQL) {
 		priorityPort = 3306
+	} else if component == string(cluster.TiCDC) {
+		priorityPort = 8301
 	}
 
 	for _, port := range ports {


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

This PR replaces deployment with tidb-operator and update monitor-initializer.

![image](https://user-images.githubusercontent.com/3251373/110639117-4848e800-81ea-11eb-8a0e-abc5db62eb76.png)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
