### PR TITLE
*: allow to customize cluster-name by flag

### DIFF
--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -119,7 +119,7 @@ func main() {
 		},
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
 		VerifySuit:  verify.Suit{},
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())

--- a/cmd/crud/main.go
+++ b/cmd/crud/main.go
@@ -46,7 +46,7 @@ func main() {
 			TxnMode:     *txnMode,
 		}},
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())

--- a/cmd/follower-read/main.go
+++ b/cmd/follower-read/main.go
@@ -52,7 +52,7 @@ func createFollowerReadCmd(cfg *control.Config) {
 		},
 		Provider:    cluster.NewDefaultClusterProvider(),
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())

--- a/cmd/pbank/main.go
+++ b/cmd/pbank/main.go
@@ -100,7 +100,7 @@ func main() {
 		NemesisGens:      util.ParseNemesisGenerators(fixture.Context.Nemesis),
 		ClientRequestGen: util.OnClientLoop,
 		VerifySuit:       verifySuit,
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())

--- a/cmd/region-available/main.go
+++ b/cmd/region-available/main.go
@@ -40,7 +40,7 @@ func main() {
 			SleepDuration:   *sleepDuration,
 		}},
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())

--- a/cmd/tpcc/main.go
+++ b/cmd/tpcc/main.go
@@ -84,7 +84,7 @@ func main() {
 		NemesisGens:      waitWarmUpNemesisGens,
 		ClientRequestGen: util.BuildClientLoopThrottle(*ticker),
 		VerifySuit:       verifySuit,
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())

--- a/pkg/test-infra/clusters.go
+++ b/pkg/test-infra/clusters.go
@@ -142,11 +142,17 @@ func (c *compositeCluster) GetClientNodes() ([]cluster.ClientNode, error) {
 
 // NewDefaultCluster creates a new TiDB cluster
 func NewDefaultCluster(namespace, name string, config fixture.TiDBClusterConfig) cluster.Cluster {
+	if len(name) == 0 {
+		name = namespace
+	}
 	return tidb.New(namespace, name, config)
 }
 
 // NewCDCCluster creates two TiDB clusters with CDC
 func NewCDCCluster(namespace, name string, upstreamConfig, downstreamConfig fixture.TiDBClusterConfig) cluster.Cluster {
+	if len(name) == 0 {
+		name = namespace
+	}
 	return NewCompositeCluster(
 		NewGroupCluster(
 			tidb.New(namespace, name+"-upstream", upstreamConfig),
@@ -158,6 +164,9 @@ func NewCDCCluster(namespace, name string, upstreamConfig, downstreamConfig fixt
 
 // NewBinlogCluster creates two TiDB clusters with Binlog
 func NewBinlogCluster(namespace, name string, conf fixture.TiDBClusterConfig) cluster.Cluster {
+	if len(name) == 0 {
+		name = namespace
+	}
 	up := tidb.New(namespace, name+"-upstream", conf)
 	upstream := up.GetTiDBCluster()
 	upstream.Spec.TiDB.BinlogEnabled = pointer.BoolPtr(true)
@@ -179,6 +188,9 @@ func NewBinlogCluster(namespace, name string, conf fixture.TiDBClusterConfig) cl
 
 // NewDMCluster creates two upstream MySQL instances and a downstream TiDB cluster with DM.
 func NewDMCluster(namespace, name string, dmConf fixture.DMConfig, tidbConf fixture.TiDBClusterConfig) cluster.Cluster {
+	if len(name) == 0 {
+		name = namespace
+	}
 	up1 := mysql.New(namespace, name+"-mysql1", dmConf.MySQLConf)
 	up2 := mysql.New(namespace, name+"-mysql2", dmConf.MySQLConf)
 	down := tidb.New(namespace, name+"-tidb", tidbConf)
@@ -190,6 +202,9 @@ func NewDMCluster(namespace, name string, dmConf fixture.DMConfig, tidbConf fixt
 
 // NewABTestCluster creates two TiDB clusters to do AB Test
 func NewABTestCluster(namespace, name string, confA, confB fixture.TiDBClusterConfig) cluster.Cluster {
+	if len(name) == 0 {
+		name = namespace
+	}
 	return NewGroupCluster(
 		tidb.New(namespace, name+"-a", confA),
 		tidb.New(namespace, name+"-b", confB),
@@ -198,11 +213,17 @@ func NewABTestCluster(namespace, name string, confA, confB fixture.TiDBClusterCo
 
 // NewTiFlashCluster creates a TiDB cluster with TiFlash
 func NewTiFlashCluster(namespace, name string, conf fixture.TiDBClusterConfig) cluster.Cluster {
+	if len(name) == 0 {
+		name = namespace
+	}
 	return tidb.New(namespace, name, conf)
 }
 
 // NewTiFlashABTestCluster creates two TiDB clusters to do AB Test, one with TiFlash
 func NewTiFlashABTestCluster(namespace, name string, confA, confB fixture.TiDBClusterConfig) cluster.Cluster {
+	if len(name) == 0 {
+		name = namespace
+	}
 	return NewGroupCluster(
 		NewTiFlashCluster(namespace, name+"-a", confA),
 		tidb.New(namespace, name+"-b", confB),
@@ -212,6 +233,9 @@ func NewTiFlashABTestCluster(namespace, name string, confA, confB fixture.TiDBCl
 // NewTiFlashCDCABTestCluster creates two TiDB clusters to do AB Test, one with TiFlash
 // This also includes a CDC cluster between the two TiDB clusters.
 func NewTiFlashCDCABTestCluster(namespace, name string, confA, confB fixture.TiDBClusterConfig) cluster.Cluster {
+	if len(name) == 0 {
+		name = namespace
+	}
 	return NewCompositeCluster(
 		NewGroupCluster(
 			NewTiFlashCluster(namespace, name+"-upstream", confA),

--- a/pkg/test-infra/fixture/fixture.go
+++ b/pkg/test-infra/fixture/fixture.go
@@ -49,6 +49,7 @@ type fixtureContext struct {
 	HistoryFile  string
 	// Test-infra
 	Namespace                string
+	ClusterName              string
 	WaitClusterReadyDuration time.Duration
 	Purge                    bool
 	DeleteNS                 bool
@@ -271,6 +272,7 @@ func init() {
 	flag.StringVar(&Context.HistoryFile, "history", "./history.log", "history file record client operation")
 
 	flag.StringVar(&Context.Namespace, "namespace", "", "test namespace")
+	flag.StringVar(&Context.ClusterName, "cluster-name", "", "test cluster name")
 	flag.StringVar(&Context.MySQLVersion, "mysql-version", "5.6", "Default mysql version")
 	flag.StringVar(&Context.DockerRepository, "repository", "pingcap", "repo name, default is pingcap")
 	flag.StringVar(&Context.LocalVolumeStorageClass, "storage-class", "local-path", "storage class name")

--- a/run/lib/case.libsonnet
+++ b/run/lib/case.libsonnet
@@ -48,10 +48,9 @@
     [
       '/bin/txn-rand-pessimistic',
     ],
-  vbank(args={ clusterName: 'vbank', connParams: '' })::
+  vbank(args={ connParams: '' })::
     [
       '/bin/vbank',
-      '-cluster-name=%s' % args.clusterName,
       '-conn_params=%s' % args.connParams,
     ],
   crossregion(args={ tso_request_count: '2000' })::

--- a/run/lib/config.libsonnet
+++ b/run/lib/config.libsonnet
@@ -19,6 +19,7 @@
       'failpoint.tidb': '',
       // k8s configurations
       namespace: '{{workflow.name}}',
+      'cluster-name': '{{workflow.name}}',
       'storage-class': 'local-path',
       purge: 'false',
       delNS: 'false',

--- a/run/workflow/vbank.jsonnet
+++ b/run/workflow/vbank.jsonnet
@@ -7,6 +7,6 @@
       // 'storage-class': 'local-storage',
       'tikv-replicas': '4',
     },
-    command: { clusterName: 'vbank', connParams: '' },
+    command: { connParams: '' },
   },
 }

--- a/testcase/bank/cmd/main.go
+++ b/testcase/bank/cmd/main.go
@@ -70,7 +70,7 @@ func main() {
 		Provider:      cluster.NewDefaultClusterProvider(),
 		ClientCreator: bank.ClientCreator{Cfg: &bankConfig},
 		NemesisGens:   util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 		LogsClient: logs.NewDiagnosticLogClient(),
 	}

--- a/testcase/bank2/cmd/main.go
+++ b/testcase/bank2/cmd/main.go
@@ -76,7 +76,7 @@ func main() {
 		},
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
 		VerifySuit:  verify.Suit{},
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 		LogsClient: logs.NewDiagnosticLogClient(),
 	}

--- a/testcase/block-writer/cmd/main.go
+++ b/testcase/block-writer/cmd/main.go
@@ -48,7 +48,7 @@ func main() {
 		Provider:      cluster.NewDefaultClusterProvider(),
 		ClientCreator: blockwriter.ClientCreator{TableNum: *tables, Concurrency: *concurrency},
 		NemesisGens:   util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 		LogsClient: logs.NewDiagnosticLogClient(),
 	}

--- a/testcase/ledger/cmd/main.go
+++ b/testcase/ledger/cmd/main.go
@@ -57,7 +57,7 @@ func main() {
 			TxnMode:     *txnMode,
 		}},
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 		LogsClient: logs.NewDiagnosticLogClient(),
 	}

--- a/testcase/list-append/cmd/main.go
+++ b/testcase/list-append/cmd/main.go
@@ -40,7 +40,7 @@ func main() {
 			Checker: listappend.AppendChecker{},
 			Parser:  listappend.AppendParser{},
 		},
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 		LogsClient: logs.NewDiagnosticLogClient(),
 	}

--- a/testcase/ondup/cmd/main.go
+++ b/testcase/ondup/cmd/main.go
@@ -52,7 +52,7 @@ func main() {
 			RetryLimit: *retryLimit,
 		}},
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())

--- a/testcase/pessimistic/cmd/deadlock-detector/main.go
+++ b/testcase/pessimistic/cmd/deadlock-detector/main.go
@@ -54,7 +54,7 @@ func main() {
 			DeadlockTimeout:  *deadlockTimeout,
 		}},
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())

--- a/testcase/pessimistic/cmd/pipelined-pessimistic-locking/main.go
+++ b/testcase/pessimistic/cmd/pipelined-pessimistic-locking/main.go
@@ -62,7 +62,7 @@ func main() {
 			LocalMode:        *localMode,
 		},
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())

--- a/testcase/pessimistic/cmd/txn-rand-pessimistic/main.go
+++ b/testcase/pessimistic/cmd/txn-rand-pessimistic/main.go
@@ -106,7 +106,7 @@ func main() {
 			},
 		}},
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())

--- a/testcase/pocket/cmd/tiflash-pocket/main.go
+++ b/testcase/pocket/cmd/tiflash-pocket/main.go
@@ -54,7 +54,7 @@ func main() {
 		},
 		NemesisGens:      util.ParseNemesisGenerators(fixture.Context.Nemesis),
 		ClientRequestGen: util.OnClientLoop,
-		ClusterDefs: test_infra.NewTiFlashCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewTiFlashCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())

--- a/testcase/rawkv-linearizability/cmd/main.go
+++ b/testcase/rawkv-linearizability/cmd/main.go
@@ -71,7 +71,7 @@ func main() {
 		NemesisGens:      util.ParseNemesisGenerators(fixture.Context.Nemesis),
 		ClientRequestGen: util.OnClientLoop,
 		VerifySuit:       verifySuit,
-		ClusterDefs:      test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace, fixture.Context.TiDBClusterConfig),
+		ClusterDefs:      test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName, fixture.Context.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())
 }

--- a/testcase/resolve-lock/cmd/resolve-lock/main.go
+++ b/testcase/resolve-lock/cmd/resolve-lock/main.go
@@ -56,7 +56,7 @@ func main() {
 			LocalMode:     *localMode,
 		}},
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())

--- a/testcase/rw-register/cmd/main.go
+++ b/testcase/rw-register/cmd/main.go
@@ -40,7 +40,7 @@ func main() {
 			Checker: rwregister.RegisterChecker{},
 			Parser:  rwregister.RegisterParser{},
 		},
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 		LogsClient: logs.NewDiagnosticLogClient(),
 	}

--- a/testcase/sqllogictest/cmd/main.go
+++ b/testcase/sqllogictest/cmd/main.go
@@ -61,7 +61,7 @@ func main() {
 			},
 		},
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.Namespace,
+		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())

--- a/testcase/vbank/cmd/main.go
+++ b/testcase/vbank/cmd/main.go
@@ -30,8 +30,6 @@ import (
 )
 
 var (
-	clusterName = flag.String("cluster-name", "", "tidb cluster name (default to namespace)")
-
 	pkType        = flag.String("pk_type", "int", "primary key type, int,decimal,string")
 	partition     = flag.Bool("partition", true, "use partitioned table")
 	useRange      = flag.Bool("range", false, "use range condition")
@@ -42,9 +40,7 @@ var (
 
 func main() {
 	flag.Parse()
-	if len(*clusterName) == 0 {
-		*clusterName = fixture.Context.Namespace
-	}
+
 	cfg := control.Config{
 		Mode:         control.ModeOnSchedule,
 		ClientCount:  fixture.Context.ClientCount,
@@ -73,7 +69,7 @@ func main() {
 		VerifySuit:       verifySuit,
 		Provider:         cluster.NewDefaultClusterProvider(),
 		NemesisGens:      util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs:      test_infra.NewDefaultCluster(fixture.Context.Namespace, *clusterName, fixture.Context.TiDBClusterConfig),
+		ClusterDefs:      test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName, fixture.Context.TiDBClusterConfig),
 		LogsClient:       logs.NewDiagnosticLogClient(),
 	}
 	suit.Run(context.Background())


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

There are too many combinations even for running a single case binary, eg. test args, tidb versions. Currently we create a namespace for each test run, which may lead to too many namespaces.

### What is changed and how does it work?

This PR allow user to customize cluster-name by flag, so that we can run cases in same namespace.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


Code changes

 - Has Go code change

Side effects

 - None

Related changes

 - None

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
