### PR TITLE
*: let rest cases use `-cluster-name` flag

### DIFF
--- a/cmd/cdc-bank/main.go
+++ b/cmd/cdc-bank/main.go
@@ -65,7 +65,7 @@ func main() {
 		},
 		NemesisGens:      waitWarmUpNemesisGens,
 		ClientRequestGen: util.OnClientLoop,
-		ClusterDefs:      test_infra.NewCDCCluster(c.Namespace, c.Namespace, c.TiDBClusterConfig, downstreamCfg),
+		ClusterDefs:      test_infra.NewCDCCluster(c.Namespace, c.ClusterName, c.TiDBClusterConfig, downstreamCfg),
 	}
 	suit.Run(context.Background())
 }

--- a/cmd/read-stress/main.go
+++ b/cmd/read-stress/main.go
@@ -59,7 +59,7 @@ func main() {
 			ReplicaRead:      *replicaRead,
 		},
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs: test_infra.NewDefaultCluster(c.Namespace, c.Namespace, c.TiDBClusterConfig),
+		ClusterDefs: test_infra.NewDefaultCluster(c.Namespace, c.ClusterName, c.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())
 }

--- a/pkg/scaffolds/template/testcase/cmd/main.go
+++ b/pkg/scaffolds/template/testcase/cmd/main.go
@@ -84,7 +84,7 @@ func main() {
 		Provider:      cluster.NewDefaultClusterProvider(),
 		ClientCreator: testcase.CaseCreator{},
 		NemesisGens:   util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs:   test_infra.NewDefaultCluster(c.Namespace, c.Namespace, c.TiDBClusterConfig),
+		ClusterDefs:   test_infra.NewDefaultCluster(c.Namespace, c.ClusterName, c.TiDBClusterConfig),
 		LogsClient:    logs.NewDiagnosticLogClient(),
 	}
 	suit.Run(context.Background())

--- a/testcase/example/cmd/main.go
+++ b/testcase/example/cmd/main.go
@@ -43,7 +43,7 @@ func main() {
 		Provider:      cluster.NewDefaultClusterProvider(),
 		ClientCreator: testcase.CaseCreator{},
 		NemesisGens:   util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs:   test_infra.NewDefaultCluster(c.Namespace, c.Namespace, c.TiDBClusterConfig),
+		ClusterDefs:   test_infra.NewDefaultCluster(c.Namespace, c.ClusterName, c.TiDBClusterConfig),
 		LogsClient:    logs.NewDiagnosticLogClient(),
 	}
 	suit.Run(context.Background())

--- a/testcase/pocket/cmd/abtest/main.go
+++ b/testcase/pocket/cmd/abtest/main.go
@@ -58,7 +58,7 @@ func main() {
 		},
 		NemesisGens:      util.ParseNemesisGenerators(fixture.Context.Nemesis),
 		ClientRequestGen: util.OnClientLoop,
-		ClusterDefs: test_infra.NewABTestCluster(c.Namespace, c.Namespace, c.TiDBClusterConfig,
+		ClusterDefs: test_infra.NewABTestCluster(c.Namespace, c.ClusterName, c.TiDBClusterConfig,
 			c.ABTestConfig.ClusterBConfig),
 	}
 	suit.Run(context.Background())

--- a/testcase/pocket/cmd/binlog-pocket/main.go
+++ b/testcase/pocket/cmd/binlog-pocket/main.go
@@ -58,7 +58,7 @@ func main() {
 		},
 		NemesisGens:      util.ParseNemesisGenerators(fixture.Context.Nemesis),
 		ClientRequestGen: util.OnClientLoop,
-		ClusterDefs:      test_infra.NewBinlogCluster(c.Namespace, c.Namespace, c.TiDBClusterConfig),
+		ClusterDefs:      test_infra.NewBinlogCluster(c.Namespace, c.ClusterName, c.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())
 }

--- a/testcase/pocket/cmd/cdc-pocket/main.go
+++ b/testcase/pocket/cmd/cdc-pocket/main.go
@@ -68,7 +68,7 @@ func main() {
 		},
 		NemesisGens:      waitWarmUpNemesisGens,
 		ClientRequestGen: util.OnClientLoop,
-		ClusterDefs:      test_infra.NewCDCCluster(c.Namespace, c.Namespace, c.TiDBClusterConfig, c.TiDBClusterConfig),
+		ClusterDefs:      test_infra.NewCDCCluster(c.Namespace, c.ClusterName, c.TiDBClusterConfig, c.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())
 }

--- a/testcase/pocket/cmd/dm-pocket/main.go
+++ b/testcase/pocket/cmd/dm-pocket/main.go
@@ -70,7 +70,7 @@ func main() {
 		},
 		NemesisGens:      waitWarmUpNemesisGens,
 		ClientRequestGen: util.OnClientLoop,
-		ClusterDefs:      test_infra.NewDMCluster(c.Namespace, c.Namespace, c.DMConfig, c.TiDBClusterConfig),
+		ClusterDefs:      test_infra.NewDMCluster(c.Namespace, c.ClusterName, c.DMConfig, c.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())
 }

--- a/testcase/pocket/cmd/tiflash-abtest/main.go
+++ b/testcase/pocket/cmd/tiflash-abtest/main.go
@@ -58,7 +58,7 @@ func main() {
 		},
 		NemesisGens:      util.ParseNemesisGenerators(c.Nemesis),
 		ClientRequestGen: util.OnClientLoop,
-		ClusterDefs:      test_infra.NewTiFlashABTestCluster(c.Namespace, c.Namespace, c.TiDBClusterConfig, c.ABTestConfig.ClusterBConfig),
+		ClusterDefs:      test_infra.NewTiFlashABTestCluster(c.Namespace, c.ClusterName, c.TiDBClusterConfig, c.ABTestConfig.ClusterBConfig),
 	}
 	suit.Run(context.Background())
 }

--- a/testcase/pocket/cmd/tiflash-cdc/main.go
+++ b/testcase/pocket/cmd/tiflash-cdc/main.go
@@ -58,7 +58,7 @@ func main() {
 		},
 		NemesisGens:      util.ParseNemesisGenerators(c.Nemesis),
 		ClientRequestGen: util.OnClientLoop,
-		ClusterDefs:      test_infra.NewTiFlashCDCABTestCluster(c.Namespace, c.Namespace, c.TiDBClusterConfig, c.ABTestConfig.ClusterBConfig),
+		ClusterDefs:      test_infra.NewTiFlashCDCABTestCluster(c.Namespace, c.ClusterName, c.TiDBClusterConfig, c.ABTestConfig.ClusterBConfig),
 	}
 	suit.Run(context.Background())
 }

--- a/testcase/titan/cmd/main.go
+++ b/testcase/titan/cmd/main.go
@@ -43,7 +43,7 @@ func main() {
 		Provider:      cluster.NewDefaultClusterProvider(),
 		ClientCreator: titan.CaseCreator{},
 		NemesisGens:   util.ParseNemesisGenerators(fixture.Context.Nemesis),
-		ClusterDefs:   test_infra.NewDefaultCluster(c.Namespace, c.Namespace, c.TiDBClusterConfig),
+		ClusterDefs:   test_infra.NewDefaultCluster(c.Namespace, c.ClusterName, c.TiDBClusterConfig),
 	}
 	suit.Run(context.Background())
 }


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Sorry, I just missed some cases in #388 .

### What is changed and how does it work?

Let those cases be aware of `-cluster-name` flag.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Side effects

 - None

Related changes

 - None

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
