### PR TITLE
skip creating namespace when the namespace is existed

### DIFF
--- a/pkg/test-infra/tests/client.go
+++ b/pkg/test-infra/tests/client.go
@@ -69,6 +69,13 @@ func (e *TestCli) CreateNamespace(name string) error {
 			Name: name,
 		},
 	}
+
+	if err := e.Cli.Get(context.TODO(), types.NamespacedName{Name: name}, ns); err == nil {
+		return nil
+	} else if !errors.IsNotFound(err) {
+		return fmt.Errorf("get namespace %s failed: %+v", name, err)
+	}
+
 	if _, err := controllerutil.CreateOrUpdate(context.TODO(), e.Cli, ns, func() error {
 		if ns.Labels != nil {
 			ns.Labels["admission-webhook"] = "enabled"


### PR DESCRIPTION
Signed-off-by: Thearas <thearas850@gmail.com>

### What problem does this PR solve?

A test may fail at `TestClient.CreateNamespace` when using a low-privileged K8S user which lacks the permission to create a namespace, even if the namespace it needs already exists.

### What is changed and how does it work?

Skip creating or updating namespace if the namespace is already existed.

### Check List <!--REMOVE the items that are not applicable-->

Tests 

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Side effects

 - None

Related changes

 - None

### Does this PR introduce a user-facing change?:
```release-note
NONE
```
