### PR TITLE
ignore context deadline exceeded error for bank2 admin check table

### DIFF
--- a/testcase/bank2/client.go
+++ b/testcase/bank2/client.go
@@ -330,7 +330,8 @@ func (c *bank2Client) verify(db *sql.DB) {
 		if strings.Contains(errStr, "1105") &&
 			!(strings.Contains(errStr, "cancelled DDL job") ||
 				strings.Contains(errStr, "Information schema is changed") ||
-				strings.Contains(errStr, "TiKV server timeout")) {
+				strings.Contains(errStr, "TiKV server timeout") ||
+				strings.Contains(errStr, "context deadline exceeded")) {
 			atomic.StoreInt32(&c.stop, 1)
 			c.wg.Wait()
 			log.Fatalf("[%s] ADMIN CHECK TABLE bank2_accounts fails: %v", c, err)


### PR DESCRIPTION
Signed-off-by: Yilin Chen <sticnarf@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Closes https://github.com/pingcap/tipocket/pull/384 again :(

### What is changed and how does it work?

I don't have a good idea about solving the problem. `ADMIN CHECK TABLE` has various error patterns and is hard to match as well. So, still, I add "context deadline exceeded" to the filter list.

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
