### PR TITLE
cross-region: adjust the WaitUntil function and its options

### DIFF
--- a/testcase/cross-region/pkg/util/util.go
+++ b/testcase/cross-region/pkg/util/util.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
+	"go.uber.org/zap"
 )
 
 // WrapErrors wrap errors into error
@@ -50,8 +51,8 @@ func WithSleepInterval(sleep time.Duration) WaitOption {
 }
 
 // WaitUntil repeatedly evaluates f() for a period of time, util it returns true.
-func WaitUntil(f CheckFunc, opts ...WaitOption) error {
-	log.Info("wait start")
+func WaitUntil(waitFor string, f CheckFunc, opts ...WaitOption) error {
+	log.Info("wait start", zap.String("wait-for", waitFor))
 	option := &WaitOp{
 		retryTimes:    waitMaxRetry,
 		sleepInterval: waitRetrySleep,
@@ -65,5 +66,5 @@ func WaitUntil(f CheckFunc, opts ...WaitOption) error {
 		}
 		time.Sleep(option.sleepInterval)
 	}
-	return fmt.Errorf("wait timeout")
+	return fmt.Errorf("wait timeout for %s", waitFor)
 }


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve? <!--add and issue link with a summary if exists-->

The current `WaitUntil` is not long enough to wait for the allocator election to finish.

### What is changed and how does it work?

I adjust the `WaitOption` to make these `WaitUntil`s wait longer.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test


### Does this PR introduce a user-facing change?:

```release-note
NONE
```
