### PR TITLE
cdc-bank: reduce checker concurrency

### DIFF
--- a/tests/cdc-bank/bank.go
+++ b/tests/cdc-bank/bank.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/ngaut/log"
-
 	"github.com/pingcap/tipocket/pkg/cluster"
 	"github.com/pingcap/tipocket/pkg/core"
 	"github.com/pingcap/tipocket/util"
@@ -49,7 +48,7 @@ func (c ClientCreator) Create(_ cluster.ClientNode) core.Client {
 
 const initBalance int = 1000
 const regions int = 16
-const validateConcurrency int = 32
+const validateConcurrency int = 1
 
 type client struct {
 	*Config


### PR DESCRIPTION

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Previously we check the downstream with 32 concurrent clients. This usually causes too much pressure at the downstream and even makes the downstream stuck.

This PR reduces it to 1.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
