### PR TITLE
Use different test logic for different TSOs

### DIFF
--- a/testcase/cross-region/tso.go
+++ b/testcase/cross-region/tso.go
@@ -47,15 +47,6 @@ func setLastTSO(dcLocation string, physical, logical int64) {
 	})
 }
 
-func checkTSOSuffix(dcLocation string, suffix int) (int, bool) {
-	suffixStored, loaded := tsoSuffix.LoadOrStore(dcLocation, suffix)
-	if !loaded {
-		return suffix, true
-	}
-	oldSuffix := suffixStored.(int)
-	return oldSuffix, oldSuffix == suffix
-}
-
 func (c *crossRegionClient) testTSO(ctx context.Context) error {
 	if err := c.requestTSOs(ctx); err != nil {
 		return err
@@ -80,18 +71,24 @@ func (c *crossRegionClient) testTSO(ctx context.Context) error {
 }
 
 func (c *crossRegionClient) requestTSOs(ctx context.Context) error {
-	dcLocationNumber := len(DCLocations)
+	if c.pdClient == nil {
+		return fmt.Errorf("pd client is not set up")
+	}
 	tsoCtx, tsoCancel := context.WithCancel(ctx)
 	defer tsoCancel()
-	tsoWg := &sync.WaitGroup{}
-	tsoWg.Add(4)
+
+	dcLocationNumber := len(DCLocations)
 	tsoErrCh := make(chan error, dcLocationNumber+1)
 	tsoCh := make(chan TSO, (dcLocationNumber+1)*c.TSORequests)
-	go c.requestTSO(tsoCtx, globalDCLocation, tsoWg, tsoCh, tsoErrCh)
+	tsoWg := &sync.WaitGroup{}
+	tsoWg.Add(dcLocationNumber + 1)
+	go c.requestGlobalTSO(tsoCtx, DCLocations, tsoWg, tsoCh, tsoErrCh)
 	for i := 0; i < dcLocationNumber; i++ {
-		go c.requestTSO(tsoCtx, DCLocations[i], tsoWg, tsoCh, tsoErrCh)
+		go c.requestLocalTSO(tsoCtx, DCLocations[i], tsoWg, tsoCh, tsoErrCh)
 	}
 	tsoWg.Wait()
+
+	// Check errors.
 	var tsoErrors []error
 	if len(tsoErrCh) < 1 {
 		log.Info("requestTSOs success")
@@ -112,6 +109,7 @@ func (c *crossRegionClient) requestTSOs(ctx context.Context) error {
 					tsoRes.physical, tsoRes.logical, tsoRes.dcLocation))
 			break
 		}
+		recordTSO[key] = struct{}{}
 	}
 	if len(tsoErrors) > 0 {
 		return util2.WrapErrors(tsoErrors)
@@ -119,28 +117,122 @@ func (c *crossRegionClient) requestTSOs(ctx context.Context) error {
 	return nil
 }
 
-func (c *crossRegionClient) requestTSO(ctx context.Context, dcLocation string, wg *sync.WaitGroup, tsoCh chan<- TSO, errCh chan<- error) {
+func (c *crossRegionClient) requestGlobalTSO(ctx context.Context, dcLocations []string, wg *sync.WaitGroup, tsoCh chan<- TSO, errCh chan<- error) {
 	defer wg.Done()
-	if c.pdClient == nil {
-		log.Error("pd client is not set up", zap.String("dc-location", dcLocation))
-		return
+	var (
+		err                                   error
+		physical, logical                     int64
+		oldSuffix                             int
+		lastGlobalPhysical, lastGlobalLogical = getLastTSO(globalDCLocation)
+		localPhysicalMap                      = make(map[string]int64, len(dcLocations))
+		localLogicalMap                       = make(map[string]int64, len(dcLocations))
+	)
+	for i := 0; i < c.TSORequests; i++ {
+		// Get all pre Local TSOs
+		for _, dcLocation := range dcLocations {
+			localPhysicalMap[dcLocation], localLogicalMap[dcLocation], err = c.pdClient.GetLocalTS(ctx, dcLocation)
+			if err != nil {
+				log.Error("requestGlobalTSO failed, get pre local tso error", zap.String("dc-location", dcLocation), zap.Error(err))
+				errCh <- err
+				return
+			}
+		}
+		// Get a Global TSO after
+		physical, logical, err = c.pdClient.GetTS(ctx)
+		if err != nil {
+			log.Error("requestGlobalTSO failed, get global tso error", zap.Error(err))
+			errCh <- err
+			return
+		}
+		log.Info("request Global TSO", zap.Int64("physical", physical), zap.Int64("logical", logical))
+		// Assert Global TSO won't fallback
+		if tsLessEqual(physical, logical, lastGlobalPhysical, lastGlobalLogical) {
+			errCh <- fmt.Errorf("tso fallback, dc-location: %s, physical: %d, logical: %d, last-physical: %d, last-logical: %d",
+				globalDCLocation, physical, logical, lastGlobalPhysical, lastGlobalLogical)
+			return
+		}
+		// Assert Global TSO is bigger than all pre Local TSOs
+		for _, dcLocation := range dcLocations {
+			preLocalPhysical := localPhysicalMap[dcLocation]
+			preLocalLogical := localLogicalMap[dcLocation]
+			if tsLessEqual(physical, logical, preLocalPhysical, preLocalLogical) {
+				errCh <- fmt.Errorf("global tso fallback than pre local tso, dc-location: %s, global-physical: %d, global-logical: %d, pre-local-physical: %d, pre-local-logical: %d",
+					dcLocation, physical, logical, preLocalPhysical, preLocalLogical)
+				return
+			}
+		}
+		// Get all after Local TSOs
+		for _, dcLocation := range dcLocations {
+			localPhysicalMap[dcLocation], localLogicalMap[dcLocation], err = c.pdClient.GetLocalTS(ctx, dcLocation)
+			if err != nil {
+				log.Error("requestGlobalTSO failed, get after local tso error", zap.String("dc-location", dcLocation), zap.Error(err))
+				errCh <- err
+				return
+			}
+		}
+		// Assert all after Local TSOs are bigger than Global TSO
+		for _, dcLocation := range dcLocations {
+			afterLocalPhysical := localPhysicalMap[dcLocation]
+			afterLocalLogical := localLogicalMap[dcLocation]
+			if tsLessEqual(afterLocalPhysical, afterLocalLogical, physical, logical) {
+				errCh <- fmt.Errorf("after local tso fallback than global tso, dc-location: %s, after-local-physical: %d, after-local-logical: %d, global-physical: %d, global-logical: %d",
+					dcLocation, afterLocalPhysical, afterLocalLogical, physical, logical)
+				return
+			}
+		}
+		// Check whether the suffix changed.
+		oldSuffix, err = checkTSOSuffix(globalDCLocation, logical)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		log.Info("matched tso suffix", zap.String("dc-location", globalDCLocation), zap.Int("suffix", oldSuffix))
+		// Finfish the request.
+		tsoCh <- TSO{physical: physical, logical: logical, dcLocation: globalDCLocation}
+		lastGlobalPhysical, lastGlobalLogical = physical, logical
+		// We should save it ASAP to make other Local TSO request goroutines can use it to compare.
+		setLastTSO(globalDCLocation, lastGlobalPhysical, lastGlobalLogical)
 	}
-	lastPhysical, lastLogical := getLastTSO(dcLocation)
+}
+
+func tsLessEqual(physical, logical, lastPhysical, lastLogical int64) bool {
+	return physical < lastPhysical || (physical == lastPhysical && logical <= lastLogical)
+}
+
+func checkTSOSuffix(dcLocation string, logical int64) (int, error) {
+	newSuffix := int(logical & suffixMask)
+	suffixStored, loaded := tsoSuffix.LoadOrStore(dcLocation, newSuffix)
+	if !loaded {
+		return newSuffix, nil
+	}
+	oldSuffix := suffixStored.(int)
+	if oldSuffix == newSuffix {
+		return oldSuffix, nil
+	}
+	return oldSuffix, fmt.Errorf("tso suffix changed, oldSuffix: %d, newSuffix: %d, dc-location: %s", oldSuffix, newSuffix, dcLocation)
+}
+
+func (c *crossRegionClient) requestLocalTSO(ctx context.Context, dcLocation string, wg *sync.WaitGroup, tsoCh chan<- TSO, errCh chan<- error) {
+	defer wg.Done()
+	var (
+		err                       error
+		physical, logical         int64
+		oldSuffix                 int
+		lastPhysical, lastLogical = getLastTSO(dcLocation)
+	)
 	for i := 0; i < c.TSORequests; i++ {
 		// Prepare the last Global TSO for the later Local TSO to compare
 		var lastGlobalTSOPhysical, lastGlobalTSOLogical int64
 		if dcLocation != globalDCLocation {
 			lastGlobalTSOPhysical, lastGlobalTSOLogical = getLastTSO(globalDCLocation)
 		}
-		physical, logical, err := c.pdClient.GetLocalTS(ctx, dcLocation)
+		physical, logical, err = c.pdClient.GetLocalTS(ctx, dcLocation)
 		if err != nil {
-			log.Error("requestTSO failed", zap.String("dc-location", dcLocation), zap.Error(err))
+			log.Error("requestLocalTSO failed", zap.String("dc-location", dcLocation), zap.Error(err))
 			errCh <- err
 			return
 		}
-		log.Info("request TSO", zap.String("dcLocation", dcLocation),
-			zap.Int64("physical", physical),
-			zap.Int64("logical", logical))
+		log.Info("request Local TSO", zap.String("dcLocation", dcLocation), zap.Int64("physical", physical), zap.Int64("logical", logical))
 		// assert tso won't fallback
 		if tsLessEqual(physical, logical, lastPhysical, lastLogical) {
 			errCh <- fmt.Errorf("tso fallback, dc-location: %s, physical: %d, logical: %d, last-physical: %d, last-logical: %d",
@@ -153,22 +245,18 @@ func (c *crossRegionClient) requestTSO(ctx context.Context, dcLocation string, w
 				dcLocation, physical, logical, lastGlobalTSOPhysical, lastGlobalTSOLogical)
 			return
 		}
-		newSuffix := int(logical & suffixMask)
-		oldSuffix, ok := checkTSOSuffix(dcLocation, newSuffix)
-		if !ok {
-			errCh <- fmt.Errorf("tso suffix changed, oldSuffix: %v, newSuffix: %v, dc-location: %v",
-				oldSuffix, newSuffix, dcLocation)
+		// Check whether the suffix changed.
+		oldSuffix, err = checkTSOSuffix(dcLocation, logical)
+		if err != nil {
+			errCh <- err
 			return
 		}
 		log.Info("matched tso suffix", zap.String("dc-location", dcLocation), zap.Int("suffix", oldSuffix))
+		// Finfish the request.
 		tsoCh <- TSO{physical: physical, logical: logical, dcLocation: dcLocation}
 		lastPhysical, lastLogical = physical, logical
 	}
 	setLastTSO(dcLocation, lastPhysical, lastLogical)
-}
-
-func tsLessEqual(physical, logical, lastPhysical, lastLogical int64) bool {
-	return physical < lastPhysical || (physical == lastPhysical && logical <= lastLogical)
 }
 
 func (c *crossRegionClient) transferPDAllocator(dcLocation string) error {


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Use different test logic for different TSOs.

### What is changed and how does it work?

* For the Global TSO test, we will request Local TSO twice before and after a Global TSO request and compare it with them.
* For the Local TSO test, we will compare it with the previous Global and Local TSO.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
