### PR TITLE
cdc-bank: fix panic caused by nil pointer

### DIFF
--- a/tests/cdc-bank/bank.go
+++ b/tests/cdc-bank/bank.go
@@ -118,7 +118,7 @@ func (c *client) Start(ctx context.Context, cfg interface{}, clientNodes []clust
 			// all previous DDL and DML are replicated too.
 			mustExec(ctx, upstream, `CREATE TABLE IF NOT EXISTS finishmark (foo BIGINT PRIMARY KEY)`)
 			waitCtx, waitCancel := context.WithTimeout(ctx, time.Minute)
-			waitTable(waitCtx, downstream, "finishmark")
+			waitTable(waitCtx, db1, "finishmark")
 			waitCancel()
 			log.Info("all tables synced")
 


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x14b68f1]

goroutine 222 [running]:
sync.(*Mutex).Lock(...)
	/usr/local/go/src/sync/mutex.go:74
database/sql.(*DB).conn(0x0, 0x1b66040, 0xc00005c030, 0xc000696001, 0x7f33a848d008, 0xc000630000, 0x0)
	/usr/local/go/src/database/sql/sql.go:1132 +0x41
database/sql.(*DB).exec(0x0, 0x1b66040, 0xc00005c030, 0x18f0c35, 0x8, 0x0, 0x0, 0x0, 0x1, 0x14c4130, ...)
	/usr/local/go/src/database/sql/sql.go:1495 +0x66
database/sql.(*DB).ExecContext(0x0, 0x1b66040, 0xc00005c030, 0x18f0c35, 0x8, 0x0, 0x0, 0x0, 0x0, 0x14004e5860, ...)
	/usr/local/go/src/database/sql/sql.go:1477 +0xde
database/sql.(*DB).Exec(...)
	/usr/local/go/src/database/sql/sql.go:1491
github.com/pingcap/tipocket/tests/cdc-bank.isTableExist(0x1b66080, 0xc000114240, 0x0, 0x18f2fd5, 0xa, 0xc0009a6570)
	/src/tests/cdc-bank/bank.go:302 +0x81
github.com/pingcap/tipocket/tests/cdc-bank.waitTable(0x1b66080, 0xc000114240, 0x0, 0x18f2fd5, 0xa)
	/src/tests/cdc-bank/bank.go:288 +0x77
github.com/pingcap/tipocket/tests/cdc-bank.(*client).Start(0xc0005a0bf8, 0x1b66080, 0xc0006960c0, 0x0, 0x0, 0xc0006e18c0, 0x2, 0x2, 0x16, 0x1)
	/src/tests/cdc-bank/bank.go:121 +0x71e
github.com/pingcap/tipocket/pkg/control.(*Controller).TransferControlToClient.func2(0xc000877768, 0x0)
	/src/pkg/control/control.go:281 +0x15b
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc0008c60c0, 0xc000670100)
	/go/pkg/mod/golang.org/x/sync@v0.0.0-20200625203802-6e8e738ad208/errgroup/errgroup.go:57 +0x64
created by golang.org/x/sync/errgroup.(*Group).Go
	/go/pkg/mod/golang.org/x/sync@v0.0.0-20200625203802-6e8e738ad208/errgroup/errgroup.go:54 +0x66
```

### What is changed and how does it work?

Avoid to pass the uninitialized `downstream` to `waitTable`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
