### PR TITLE
cross-region: only fail the test if a critical error occurs

### DIFF
--- a/testcase/cross-region/cmd/main.go
+++ b/testcase/cross-region/cmd/main.go
@@ -67,12 +67,12 @@ func provideCrossRegionCluster() cluster.Cluster {
 	crossregion.DCLocations = names
 
 	confs := []fixture.TiDBClusterConfig{
-		provideConf(2, 1, 1, nil, names[0]),
-		provideConf(2, 1, 1, &fixture.ClusterRef{
+		provideConf(2, 1, 0, nil, names[0]),
+		provideConf(2, 0, 0, &fixture.ClusterRef{
 			Name:      names[0],
 			Namespace: namespace,
 		}, names[1]),
-		provideConf(2, 1, 1, &fixture.ClusterRef{
+		provideConf(2, 0, 0, &fixture.ClusterRef{
 			Name:      names[0],
 			Namespace: namespace,
 		}, names[2]),

--- a/testcase/cross-region/go.sum
+++ b/testcase/cross-region/go.sum
@@ -123,7 +123,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cfssl v0.0.0-20180726162950-56268a613adf/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313/go.mod h1:P1wt9Z3DP8O6W3rvwCt0REIlshg1InHImaLW0t3ObY0=
-github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa h1:OaNxuTZr7kxeODyLWsRMC+OD03aFUH+mW6r2d+MWa5Y=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
@@ -447,7 +446,6 @@ github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=

--- a/testcase/cross-region/tso.go
+++ b/testcase/cross-region/tso.go
@@ -53,7 +53,7 @@ func (cte *criticalTSOError) Error() string {
 	case suffixChangedError:
 		errTypeMsg = "suffixChangedError"
 	}
-	return fmt.Sprintf("%s: %s", errTypeMsg, cte.msg)
+	return fmt.Sprintf("criticalTSOError: %s, %s", errTypeMsg, cte.msg)
 }
 
 // TSO wraps the tso response

--- a/testcase/cross-region/tso.go
+++ b/testcase/cross-region/tso.go
@@ -406,7 +406,7 @@ func (c *crossRegionClient) waitAllocatorReady(dcLocations []string) error {
 
 func (c *crossRegionClient) waitLeader(name string) error {
 	for {
-		fmt.Printf("Wait for %s leader election\n", name)
+		log.Info("Wait for leader election", zap.String("name", name))
 		mems, err := c.pdHTTPClient.GetMembers()
 		if err != nil {
 			return err
@@ -420,7 +420,7 @@ func (c *crossRegionClient) waitLeader(name string) error {
 
 func (c *crossRegionClient) waitAllocator(name, dcLocation string) error {
 	for {
-		fmt.Printf("Wait for %s of %s allocator election\n", name, dcLocation)
+		log.Info("Wait for allocator election", zap.String("name", name), zap.String("dc-location", dcLocation))
 		members, err := c.pdHTTPClient.GetMembers()
 		if err != nil {
 			return err

--- a/testcase/cross-region/tso.go
+++ b/testcase/cross-region/tso.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
@@ -17,6 +18,43 @@ const (
 	logicalMask       = (1 << physicalShiftBits) - 1
 	suffixMask        = logicalMask >> (physicalShiftBits - 2) // Log2(3+1) = 2
 )
+
+type criticalTSOErrorType int
+
+const (
+	// fallbackError indicates the TSO fallback occurs.
+	fallbackError criticalTSOErrorType = iota
+	// uniquenessError indicates the TSO is not unique.
+	uniquenessError
+	// suffixChangedError indicates the TSO suffix changed unexpectedly.
+	suffixChangedError
+)
+
+// criticalTSOError represents the critical error which should never occur.
+type criticalTSOError struct {
+	errType criticalTSOErrorType
+	msg     string
+}
+
+func newCriticalTSOError(errType criticalTSOErrorType, msg string) *criticalTSOError {
+	return &criticalTSOError{
+		errType: errType,
+		msg:     msg,
+	}
+}
+
+func (cte *criticalTSOError) Error() string {
+	var errTypeMsg string
+	switch cte.errType {
+	case fallbackError:
+		errTypeMsg = "fallbackError"
+	case uniquenessError:
+		errTypeMsg = "uniquenessError"
+	case suffixChangedError:
+		errTypeMsg = "suffixChangedError"
+	}
+	return fmt.Sprintf("%s: %s", errTypeMsg, cte.msg)
+}
 
 // TSO wraps the tso response
 type TSO struct {
@@ -105,14 +143,23 @@ func (c *crossRegionClient) requestTSOs(ctx context.Context) error {
 		_, ok := recordTSO[key]
 		if ok {
 			tsoErrors = append(tsoErrors,
-				fmt.Errorf("tso repeated, physical: %v, logical: %v, dc-location %v",
-					tsoRes.physical, tsoRes.logical, tsoRes.dcLocation))
+				newCriticalTSOError(
+					uniquenessError,
+					fmt.Sprintf("tso repeated, physical: %v, logical: %v, dc-location %v",
+						tsoRes.physical, tsoRes.logical, tsoRes.dcLocation)))
 			break
 		}
 		recordTSO[key] = struct{}{}
 	}
-	if len(tsoErrors) > 0 {
-		return util2.WrapErrors(tsoErrors)
+	// Only return the critical errors.
+	criticalTSOErrors := make([]error, 0, len(tsoErrors))
+	for _, err := range tsoErrors {
+		if _, ok := err.(*criticalTSOError); ok {
+			criticalTSOErrors = append(criticalTSOErrors, err)
+		}
+	}
+	if len(criticalTSOErrors) > 0 {
+		return util2.WrapErrors(criticalTSOErrors)
 	}
 	return nil
 }
@@ -147,8 +194,10 @@ func (c *crossRegionClient) requestGlobalTSO(ctx context.Context, dcLocations []
 		log.Info("request Global TSO", zap.Int64("physical", physical), zap.Int64("logical", logical))
 		// Assert Global TSO won't fallback
 		if tsLessEqual(physical, logical, lastGlobalPhysical, lastGlobalLogical) {
-			errCh <- fmt.Errorf("tso fallback, dc-location: %s, physical: %d, logical: %d, last-physical: %d, last-logical: %d",
-				globalDCLocation, physical, logical, lastGlobalPhysical, lastGlobalLogical)
+			errCh <- newCriticalTSOError(
+				fallbackError,
+				fmt.Sprintf("tso fallback, dc-location: %s, physical: %d, logical: %d, last-physical: %d, last-logical: %d",
+					globalDCLocation, physical, logical, lastGlobalPhysical, lastGlobalLogical))
 			return
 		}
 		// Assert Global TSO is bigger than all pre Local TSOs
@@ -156,8 +205,10 @@ func (c *crossRegionClient) requestGlobalTSO(ctx context.Context, dcLocations []
 			preLocalPhysical := localPhysicalMap[dcLocation]
 			preLocalLogical := localLogicalMap[dcLocation]
 			if tsLessEqual(physical, logical, preLocalPhysical, preLocalLogical) {
-				errCh <- fmt.Errorf("global tso fallback than pre local tso, dc-location: %s, global-physical: %d, global-logical: %d, pre-local-physical: %d, pre-local-logical: %d",
-					dcLocation, physical, logical, preLocalPhysical, preLocalLogical)
+				errCh <- newCriticalTSOError(
+					fallbackError,
+					fmt.Sprintf("global tso fallback than pre local tso, dc-location: %s, global-physical: %d, global-logical: %d, pre-local-physical: %d, pre-local-logical: %d",
+						dcLocation, physical, logical, preLocalPhysical, preLocalLogical))
 				return
 			}
 		}
@@ -175,8 +226,10 @@ func (c *crossRegionClient) requestGlobalTSO(ctx context.Context, dcLocations []
 			afterLocalPhysical := localPhysicalMap[dcLocation]
 			afterLocalLogical := localLogicalMap[dcLocation]
 			if tsLessEqual(afterLocalPhysical, afterLocalLogical, physical, logical) {
-				errCh <- fmt.Errorf("after local tso fallback than global tso, dc-location: %s, after-local-physical: %d, after-local-logical: %d, global-physical: %d, global-logical: %d",
-					dcLocation, afterLocalPhysical, afterLocalLogical, physical, logical)
+				errCh <- newCriticalTSOError(
+					fallbackError,
+					fmt.Sprintf("after local tso fallback than global tso, dc-location: %s, after-local-physical: %d, after-local-logical: %d, global-physical: %d, global-logical: %d",
+						dcLocation, afterLocalPhysical, afterLocalLogical, physical, logical))
 				return
 			}
 		}
@@ -209,7 +262,7 @@ func checkTSOSuffix(dcLocation string, logical int64) (int, error) {
 	if oldSuffix == newSuffix {
 		return oldSuffix, nil
 	}
-	return oldSuffix, fmt.Errorf("tso suffix changed, oldSuffix: %d, newSuffix: %d, dc-location: %s", oldSuffix, newSuffix, dcLocation)
+	return oldSuffix, newCriticalTSOError(suffixChangedError, fmt.Sprintf("tso suffix changed, oldSuffix: %d, newSuffix: %d, dc-location: %s", oldSuffix, newSuffix, dcLocation))
 }
 
 func (c *crossRegionClient) requestLocalTSO(ctx context.Context, dcLocation string, wg *sync.WaitGroup, tsoCh chan<- TSO, errCh chan<- error) {
@@ -352,31 +405,33 @@ func (c *crossRegionClient) waitAllocatorReady(dcLocations []string) error {
 }
 
 func (c *crossRegionClient) waitLeader(name string) error {
-	return util2.WaitUntil(fmt.Sprintf("%s leader election", name), func() bool {
+	for {
+		fmt.Printf("Wait for %s leader election\n", name)
 		mems, err := c.pdHTTPClient.GetMembers()
 		if err != nil {
-			return false
+			return err
 		}
-		if mems.Leader == nil || mems.Leader.Name != name {
-			return false
+		if mems.Leader != nil && mems.Leader.Name == name {
+			return nil
 		}
-		return true
-	})
+		time.Sleep(30 * time.Second)
+	}
 }
 
 func (c *crossRegionClient) waitAllocator(name, dcLocation string) error {
-	return util2.WaitUntil(fmt.Sprintf("%s of %s allocator election", name, dcLocation), func() bool {
+	for {
+		fmt.Printf("Wait for %s of %s allocator election\n", name, dcLocation)
 		members, err := c.pdHTTPClient.GetMembers()
 		if err != nil {
-			return false
+			return err
 		}
 		for dc, member := range members.TsoAllocatorLeaders {
 			if dcLocation == dc && member.Name == name {
-				return true
+				return nil
 			}
 		}
-		return false
-	})
+		time.Sleep(30 * time.Second)
+	}
 }
 
 func (c *crossRegionClient) requestTSOAfterTransfer(ctx context.Context, dc string) {


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Currently, there are many test failures that are caused by timeouts due to resource constraints. To improve test success rate and focus on the TSO consistency check, we need to handle this situation.

### What is changed and how does it work?

- Only fail the cross-region test if a critical error occurs.
- Wait for leader election without any timeout.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
