### PR TITLE
cross-region: fix the potential panic bug

### DIFF
--- a/testcase/cross-region/tso.go
+++ b/testcase/cross-region/tso.go
@@ -430,7 +430,7 @@ func (c *crossRegionClient) waitAllocator(name, dcLocation string) error {
 		}
 		if members != nil && members.TsoAllocatorLeaders != nil {
 			for dc, member := range members.TsoAllocatorLeaders {
-				if dcLocation == dc && member.Name == name {
+				if dcLocation == dc && member != nil && member.Name == name {
 					return nil
 				}
 			}


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

```
[2021/06/21 06:32:29.524 +00:00] [INFO] [tso.go:426] ["Wait for allocator election"] [name=cross-region-chaos-1624256277-dc-2-pd-1] [dc-location=cross-region-chaos-1624256277-dc-2]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x16c93f8]

goroutine 689 [running]:
github.com/pingcap/tipocket/testcase/cross-region.(*crossRegionClient).waitAllocator(0xc000820600, 0xc000a36c30, 0x27, 0xc00025e5a0, 0x22, 0x0, 0x0)
/src/testcase/cross-region/tso.go:433 +0x338
github.com/pingcap/tipocket/testcase/cross-region.(*crossRegionClient).transferPDAllocator(0xc000820600, 0xc00025e5a0, 0x22, 0x0, 0x0)
/src/testcase/cross-region/tso.go:354 +0x754
github.com/pingcap/tipocket/testcase/cross-region.(*crossRegionClient).testTSO(0xc000820600, 0x1c93d68, 0xc000b3e8a0, 0x1, 0x1)
/src/testcase/cross-region/tso.go:99 +0x11a
github.com/pingcap/tipocket/testcase/cross-region.(*crossRegionClient).Start(0xc000820600, 0x1c93d68, 0xc000b3e8a0, 0x0, 0x0, 0xc000293b00, 0x3, 0x4, 0x696b222c22316168, 0x646954223a22646e
/src/testcase/cross-region/cross-region.go:104 +0x175
github.com/pingcap/tipocket/pkg/control.(*Controller).TransferControlToClient.func2(0x2c343a226e6f6974, 0x22736c6562616c22)
/src/pkg/control/control.go:281 +0x15b
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc000982510, 0xc000bca540)
/go/pkg/mod/golang.org/x/sync@v0.0.0-20200625203802-6e8e738ad208/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
/go/pkg/mod/golang.org/x/sync@v0.0.0-20200625203802-6e8e738ad208/errgroup/errgroup.go:54 +0x66
```

### What is changed and how does it work?

Fix the potential panic bug caused by `nil` member.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test

### Does this PR introduce a user-facing change?:

```release-note
NONE
```
