### PR TITLE
bank2: ignore error 1105 without message

### DIFF
--- a/testcase/bank2/client.go
+++ b/testcase/bank2/client.go
@@ -392,7 +392,7 @@ func (c *bank2Client) verify(ctx context.Context, db *sql.DB) {
 				strings.Contains(errStr, "redirect failed") ||
 				strings.Contains(errStr, "no leader") ||
 				strings.Contains(errStr, "injected") ||
-				(strings.Split(errStr, ":")[1] == "")) {
+				(errStr == "Error 1105: ")) {
 			atomic.StoreInt32(&c.stop, 1)
 			c.wg.Wait()
 			log.Fatalf("[%s] ADMIN CHECK TABLE bank2_accounts fails: %v", c, err)

--- a/testcase/bank2/client.go
+++ b/testcase/bank2/client.go
@@ -391,7 +391,8 @@ func (c *bank2Client) verify(ctx context.Context, db *sql.DB) {
 				strings.Contains(errStr, "TiKV server timeout") ||
 				strings.Contains(errStr, "redirect failed") ||
 				strings.Contains(errStr, "no leader") ||
-				strings.Contains(errStr, "injected")) {
+				strings.Contains(errStr, "injected") ||
+				(strings.Split(errStr, ":")[1] == "")) {
 			atomic.StoreInt32(&c.stop, 1)
 			c.wg.Wait()
 			log.Fatalf("[%s] ADMIN CHECK TABLE bank2_accounts fails: %v", c, err)


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

tidb sometimes return error 1105 without message, just ignore it.

![2021-07-12_194119](https://user-images.githubusercontent.com/6850317/125281744-2e124880-e349-11eb-943b-9cce0db3e19b.png)

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
