### PR TITLE
bank2: ignore error 1105 with message:context deadline exceeded

### DIFF
--- a/testcase/bank2/client.go
+++ b/testcase/bank2/client.go
@@ -392,6 +392,7 @@ func (c *bank2Client) verify(ctx context.Context, db *sql.DB) {
 				strings.Contains(errStr, "redirect failed") ||
 				strings.Contains(errStr, "no leader") ||
 				strings.Contains(errStr, "injected") ||
+				strings.Contains(errStr, "context deadline exceeded") ||
 				(errStr == "Error 1105: ")) {
 			atomic.StoreInt32(&c.stop, 1)
 			c.wg.Wait()


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

tidb sometimes return error 1105 with message：context deadline exceeded, just ignore it.

2021/07/21 18:06:33 client.go:398: [fatal] [bank2] ADMIN CHECK TABLE bank2_accounts fails: Error 1105: context deadline exceeded

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
NONE
