### PR TITLE
bank2: ignore `raft: stopped` when doing admin check table

### DIFF
--- a/testcase/bank2/client.go
+++ b/testcase/bank2/client.go
@@ -394,6 +394,7 @@ func (c *bank2Client) verify(ctx context.Context, db *sql.DB) {
 				strings.Contains(errStr, "injected") ||
 				strings.Contains(errStr, "context deadline exceeded") ||
 				strings.Contains(errStr, "redirect to not leader") ||
+				strings.Contains(errStr, "raft: stopped") ||
 				(errStr == "Error 1105: ")) {
 			atomic.StoreInt32(&c.stop, 1)
 			c.wg.Wait()


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

`admin check table` may fail with `Error 1105: rpc error: code = Unknown desc = raft: stopped`, it's expected if pd nemeses are introduced.

### What is changed and how does it work?

Add such an error to the whitelist.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Side effects

 - None

Related changes

 - None

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
