### PR TITLE
do not fail if resolve lock returns region unavailable

### DIFF
--- a/testcase/resolve-lock/cmd/resolve-lock/main.go
+++ b/testcase/resolve-lock/cmd/resolve-lock/main.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"flag"
 
+	logs "github.com/pingcap/tipocket/logsearch/pkg/logs"
+
 	// use mysql
 	_ "github.com/go-sql-driver/mysql"
 
@@ -58,6 +60,7 @@ func main() {
 		NemesisGens: util.ParseNemesisGenerators(fixture.Context.Nemesis),
 		ClusterDefs: test_infra.NewDefaultCluster(fixture.Context.Namespace, fixture.Context.ClusterName,
 			fixture.Context.TiDBClusterConfig),
+		LogsClient: logs.NewDiagnosticLogClient(),
 	}
 	suit.Run(context.Background())
 }

--- a/testcase/resolve-lock/go.mod
+++ b/testcase/resolve-lock/go.mod
@@ -6,10 +6,11 @@ require (
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/ngaut/log v0.0.0-20180314031856-b8e36e7ba5ac
 	github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011
-	github.com/pingcap/kvproto v0.0.0-20200324130106-b8bc94dd8a36
+	github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c
 	github.com/pingcap/pd/v4 v4.0.0-beta.1.0.20200305072537-61d9f9cc35d3
 	github.com/pingcap/tidb v2.1.0-beta+incompatible
 	github.com/pingcap/tipocket v1.0.0
+	github.com/pingcap/tipocket/logsearch v0.0.0-20210820013836-9e41b607c358
 )
 
 replace google.golang.org/grpc => google.golang.org/grpc v1.26.0

--- a/testcase/resolve-lock/go.sum
+++ b/testcase/resolve-lock/go.sum
@@ -657,8 +657,8 @@ github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO
 github.com/pingcap/kvproto v0.0.0-20200214064158-62d31900d88e/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20200221034943-a2aa1d1e20a8/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20200228095611-2cf9a243b8d5/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20200324130106-b8bc94dd8a36 h1:iMv4VoavfOBKjKdp+E6qydAoGsQLEf8PRokU12CSa0A=
-github.com/pingcap/kvproto v0.0.0-20200324130106-b8bc94dd8a36/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c h1:wO9VvZezAU4ZPZj8+P5uWfsT/ppuABjJPmHNrpCQnlc=
+github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad h1:SveG82rmu/GFxYanffxsSF503SiQV+2JLnWEiGiF+Tc=
@@ -678,6 +678,8 @@ github.com/pingcap/tidb-tools v4.0.0-beta.1.0.20200306084441-875bd09aa3d5+incomp
 github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pingcap/tipb v0.0.0-20200212061130-c4d518eb1d60 h1:aJPXrT1u4VfUSGFA2oQVwl4pOXzqe+YI6wed01cjDH4=
 github.com/pingcap/tipb v0.0.0-20200212061130-c4d518eb1d60/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
+github.com/pingcap/tipocket/logsearch v0.0.0-20210820013836-9e41b607c358 h1:Qzt4OBtqxZu5ZcnCZ3U8c+Bqie7EfkQrvbBvbArekbM=
+github.com/pingcap/tipocket/logsearch v0.0.0-20210820013836-9e41b607c358/go.mod h1:M9zy1Tk+G9KvfosDdIbFoZH+j089QjiWtYZRFi9MCAY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/testcase/resolve-lock/resolve_lock.go
+++ b/testcase/resolve-lock/resolve_lock.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -230,8 +231,10 @@ func (c *resolveLockClient) Start(ctx context.Context, cfg interface{}, clientNo
 		// Invoke GC with the safe point
 		greenGCUsed, err := c.resolveLocks(ctx)
 		if err != nil {
-			log.Errorf("[round-%d] failed to run GC at safe point %v", loopNum, c.safePoint)
-			return errors.Trace(err)
+			if !strings.Contains(err.Error(), "region unavailable") {
+				log.Errorf("[round-%d] failed to run GC at safe point %v", loopNum, c.safePoint)
+				return errors.Trace(err)
+			}
 		}
 		log.Infof("[round-%d] GC done at safePoint(%v)", loopNum, c.safePoint)
 

--- a/testcase/resolve-lock/resolve_lock.go
+++ b/testcase/resolve-lock/resolve_lock.go
@@ -229,12 +229,20 @@ func (c *resolveLockClient) Start(ctx context.Context, cfg interface{}, clientNo
 		}
 		log.Infof("[round-%d] start to GC at safePoint(%v)", loopNum, c.safePoint)
 		// Invoke GC with the safe point
-		greenGCUsed, err := c.resolveLocks(ctx)
-		if err != nil {
+		var greenGCUsed bool
+		for i := 0; i < 5; i++ {
+			greenGCUsed, err = c.resolveLocks(ctx)
+			if err == nil {
+				break
+			}
 			if !strings.Contains(err.Error(), "region unavailable") {
 				log.Errorf("[round-%d] failed to run GC at safe point %v", loopNum, c.safePoint)
 				return errors.Trace(err)
 			}
+		}
+		if err != nil {
+			log.Errorf("[round-%d] failed to resolve locks for 5 times at safe point %v", loopNum, c.safePoint)
+			return errors.Trace(err)
 		}
 		log.Infof("[round-%d] GC done at safePoint(%v)", loopNum, c.safePoint)
 

--- a/testcase/resolve-lock/resolve_lock.go
+++ b/testcase/resolve-lock/resolve_lock.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -551,7 +552,9 @@ func (c *resolveLockClient) reset(ctx context.Context) {
 
 func (c *resolveLockClient) getTs(ctx context.Context) (uint64, error) {
 	physical, logical, err := c.pd.GetTS(ctx)
-	if err != nil {
+	//if pd down, errmsg is io.EOF,testcase ignore this errmsg
+	//panic_check plugin check pd panic
+	if err != nil && err != io.EOF {
 		return 0, errors.Trace(err)
 	}
 	ts := oracle.ComposeTS(physical, logical)


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

the testcase return error message as follow，because nemesis：pd-scheduler random-merge-scheduler

2021/09/07 05:23:35 pd_scheduler.go:59: [info] apply nemesis pd-scheduler random-merge-scheduler on ns tipocket-debug-nrrdr
2021/09/07 05:23:35 pd_scheduler.go:63: [info] add scheduler random-merge-scheduler successfully
2021/09/07 05:27:34 resolve_lock.go:233: [error] [round-35] failed to run GC at safe point 427552777833021443
2021/09/07 05:27:34 resolve_lock.go:194: [info] test end 
2021/09/07 05:27:34 control.go:285: [fatal] run client error, GET request "http://debug-tidb.tipocket-debug-nrrdr.svc:10080/test/gc/resolvelock?safepoint=427552777833021443&physical=false", got 400 resolveLocks failed: region unavailable


### What is changed and how does it work?
none

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
