### PR TITLE
fix comparing getTS error

### DIFF
--- a/testcase/resolve-lock/resolve_lock.go
+++ b/testcase/resolve-lock/resolve_lock.go
@@ -562,7 +562,7 @@ func (c *resolveLockClient) getTs(ctx context.Context) (uint64, error) {
 	bo := tikv.NewBackoffer(ctx, 60000)
 	for {
 		physical, logical, err := c.pd.GetTS(ctx)
-		switch err {
+		switch errors.Cause(err) {
 		case nil:
 			ts := oracle.ComposeTS(physical, logical)
 			return ts, nil


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

PD client wraps the raw error so that the error comparison fails. https://github.com/tikv/pd/blob/1db2398d1a508a1679ef51f5e06133cc821becbd/client/client.go#L949
