### PR TITLE
resolve_lock: fix resolve lock error comparison

### DIFF
--- a/testcase/resolve-lock/resolve_lock.go
+++ b/testcase/resolve-lock/resolve_lock.go
@@ -242,7 +242,8 @@ func (c *resolveLockClient) Start(ctx context.Context, cfg interface{}, clientNo
 			if err == nil {
 				break
 			}
-			if !(strings.Contains(err.Error(), "region unavailable") || strings.Contains(err.Error(), "Region is unavailable")) {
+			if !(strings.Contains(err.Error(), "region unavailable") || strings.Contains(err.Error(), "Region is unavailable")) &&
+				!strings.Contains(err.Error(), "unexpected scanlock error: error:<locked") {
 				log.Errorf("[round-%d] failed to run GC at safe point %v", loopNum, c.safePoint)
 				return errors.Trace(err)
 			}


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

Different versions TiDB returns different errors when resolving locks:
```
GET request \"http://tipocket-green-gc-off-v50-tidb.tipocket-green-gc-off-v50-1633131000.svc:10080/test/gc/resolvelock?safepoint=428116361171697667&physical=false\", got 400 resolveLocks failed: [tikv:9005]Region is unavailable\n"}}
```

And `ScanLock` may fail due to the memory lock in TiKV, the error is retryable too.
```
GET request "http://tipocket-green-gc-off-v52-tidb.tipocket-green-gc-off-v52-1633390200.svc:10080/test/gc/resolvelock?safepoint=428184419383115779&physical=false", got 400 resolveLocks failed: unexpected scanlock error: error:<locked:<primary_lock:"t\200\000\000\000\000\000\000\025_i\200\000\000\000\000\000\000\002\003\200\000\000\000\000\000\000\021" lock_version:428184419383115778 key:"t\200\000\000\000\000\000\000\025_i\200\000\000\000\000\000\000\002\003\200\000\000\000\000\000\000\021" lock_ttl:20001 txn_size:1 lock_type:Lock lock_for_update_ts:428184419383115778 use_async_commit:true min_commit_ts:428184419383115781 > > 
```

### What is changed and how does it work?

Compare the `Region is unavailable` error message.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - No code

Code changes

Side effects

Related changes


### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
