### PR TITLE
ignore error:context canceled because of network delay

### DIFF
--- a/testcase/resolve-lock/resolve_lock.go
+++ b/testcase/resolve-lock/resolve_lock.go
@@ -568,7 +568,7 @@ func (c *resolveLockClient) getTs(ctx context.Context) (uint64, error) {
 			ts := oracle.ComposeTS(physical, logical)
 			return ts, nil
 
-		case io.EOF, errors.New("context canceled"):
+		case io.EOF, context.Canceled:
 			// If the error is caused by PD panic, the panic_check plugin checks it.
 			//
 			// PD may be killed due to the test environment and it may recover,

--- a/testcase/resolve-lock/resolve_lock.go
+++ b/testcase/resolve-lock/resolve_lock.go
@@ -568,7 +568,7 @@ func (c *resolveLockClient) getTs(ctx context.Context) (uint64, error) {
 			ts := oracle.ComposeTS(physical, logical)
 			return ts, nil
 
-		case io.EOF:
+		case io.EOF, errors.New("context canceled"):
 			// If the error is caused by PD panic, the panic_check plugin checks it.
 			//
 			// PD may be killed due to the test environment and it may recover,

--- a/testcase/resolve-lock/resolve_lock.go
+++ b/testcase/resolve-lock/resolve_lock.go
@@ -569,11 +569,16 @@ func (c *resolveLockClient) getTs(ctx context.Context) (uint64, error) {
 			return ts, nil
 
 		case io.EOF, context.Canceled:
+			//client return error context.Canceled actively
+			if ctx.Err() != nil {
+				return 0, nil
+			}
+
 			// If the error is caused by PD panic, the panic_check plugin checks it.
-			//
-			// PD may be killed due to the test environment and it may recover,
+			// PD may be killed or return error context.Cancele due to the test environment and it may recover,
 			// so we backoff for a while and if PD doesn't recover in time, we
 			// think the test finishes to avoid false-negative.
+
 			err = bo.Backoff(tikv.BoPDRPC, err)
 			if err != nil {
 				return 0, nil

--- a/testcase/resolve-lock/resolve_lock.go
+++ b/testcase/resolve-lock/resolve_lock.go
@@ -575,7 +575,7 @@ func (c *resolveLockClient) getTs(ctx context.Context) (uint64, error) {
 			}
 
 			// If the error is caused by PD panic, the panic_check plugin checks it.
-			// PD may be killed or return error context.Cancele due to the test environment and it may recover,
+			// PD may be killed or return error context.Canceled due to the test environment and it may recover,
 			// so we backoff for a while and if PD doesn't recover in time, we
 			// think the test finishes to avoid false-negative.
 

--- a/testcase/resolve-lock/resolve_lock.go
+++ b/testcase/resolve-lock/resolve_lock.go
@@ -569,7 +569,7 @@ func (c *resolveLockClient) getTs(ctx context.Context) (uint64, error) {
 			return ts, nil
 
 		case io.EOF, context.Canceled:
-			//client return error context.Canceled actively
+			// client return error context.Canceled actively
 			if ctx.Err() != nil {
 				return 0, nil
 			}


### PR DESCRIPTION
### What problem does this PR solve? 

test case failed because of getTS timeout：
```
[2021/12/04 04:23:17.849 +00:00] [ERROR] [client.go:259] ["[pd] getTS error"] [error="rpc error: code = Canceled desc = context canceled"] [errorVerbose="rpc error: code = Canceled desc = context canceled\ngithub.com/pingcap/pd/v4/client.(*client).processTSORequests\n\t/go/pkg/mod/github.com/pingcap/pd/v4@v4.0.0-beta.1.0.20200305072537-61d9f9cc35d3/client/client.go:295\ngithub.com/pingcap/pd/v4/client.(*client).tsLoop\n\t/go/pkg/mod/github.com/pingcap/pd/v4@v4.0.0-beta.1.0.20200305072537-61d9f9cc35d3/client/client.go:244\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1371"] [stack="github.com/pingcap/log.Error\n\t/go/pkg/mod/github.com/pingcap/log@v0.0.0-20200511115504-543df19646ad/global.go:42\ngithub.com/pingcap/pd/v4/client.(*client).tsLoop\n\t/go/pkg/mod/github.com/pingcap/pd/v4@v4.0.0-beta.1.0.20200305072537-61d9f9cc35d3/client/client.go:259"]
[2021/12/04 04:23:23.424 +00:00] [WARN] [pd.go:109] ["get timestamp too slow"] ["cost time"=470.040457ms]
2021/12/04 04:23:28 resolve_lock.go:196: [info] test end 
2021/12/04 04:23:28 control.go:285: [fatal] run client error, rpc error: code = Canceled desc = context canceled
```

http://172.16.4.180:31714/archived-workflows/test-store/b681e0bc-a198-4982-ab89-95da656954fe?nodeId=tipocket-green-gc-off-v52-1638574200


### What is changed and how does it work?

ignore error: context canceled

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
