### PR TITLE
stale read: reconnect when read request met errors

### DIFF
--- a/testcase/stale-read/go.mod
+++ b/testcase/stale-read/go.mod
@@ -4,7 +4,6 @@ go 1.16
 
 require (
 	github.com/ngaut/log v0.0.0-20180314031856-b8e36e7ba5ac
-	github.com/pingcap/tidb v2.0.11+incompatible
 	github.com/pingcap/tipocket v1.0.0
 )
 

--- a/testcase/stale-read/go.sum
+++ b/testcase/stale-read/go.sum
@@ -527,8 +527,6 @@ github.com/pingcap/go-tpc v0.0.0-20200229030315-98ee0f8f09d3/go.mod h1:YToE6BW+r
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad h1:SveG82rmu/GFxYanffxsSF503SiQV+2JLnWEiGiF+Tc=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
-github.com/pingcap/tidb v2.0.11+incompatible h1:Shz+ry1DzQNsPk1QAejnM+5tgjbwZuzPnIER5aCjQ6c=
-github.com/pingcap/tidb v2.0.11+incompatible/go.mod h1:I8C6jrPINP2rrVunTRd7C9fRRhQrtR43S1/CL5ix/yQ=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
Signed-off-by: linning <linningde25@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

When read request met error, the connection will be closed and incoming requests sent with the connection will be failed too

### What is changed and how does it work?

Backoff and establish a new connection for incoming requests

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
