### PR TITLE
stale-read: fix connection error

### DIFF
--- a/run/workflow/stale-read.jsonnet
+++ b/run/workflow/stale-read.jsonnet
@@ -7,7 +7,7 @@
       // 'storage-class': 'local-storage',
       'tikv-config': '/config/tikv/small-region.toml',
       'tikv-replicas': '4',
-      nemesis: 'delay,loss,kill_tikv_1node_5min,short_kill_tikv_1node,random-merge-scheduler,shuffle-leader-scheduler,shuffle-region-scheduler,partition_one',
+      nemesis: 'delay,kill_tikv_1node_5min,short_kill_tikv_1node,random-merge-scheduler,shuffle-leader-scheduler,shuffle-region-scheduler',
     },
     command: {},
   },


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

When establishing a new connection, the old one is not closed. Also, the connection used for background updating is not re-establish when met error.

### What is changed and how does it work?

Close the old connection and re-establish the connection for the background updating job. This PR also removes some network nemeses that may cause the connection of TiDB to become invalid.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
