### PR TITLE
support tidb-operator v1.3.0

### DIFF
--- a/pkg/test-infra/clusters.go
+++ b/pkg/test-infra/clusters.go
@@ -170,12 +170,14 @@ func NewBinlogCluster(namespace, name string, conf fixture.TiDBClusterConfig) cl
 	up := tidb.New(namespace, name+"-upstream", conf)
 	upstream := up.GetTiDBCluster()
 	upstream.Spec.TiDB.BinlogEnabled = pointer.BoolPtr(true)
+	baseImage, version := util.BuildBaseImageAndVersion("tidb-binlog", fixture.Context.TiDBClusterConfig.ImageVersion, fixture.Context.BinlogConfig.Image)
 	upstream.Spec.Pump = &v1alpha1.PumpSpec{
 		Replicas:             3,
 		ResourceRequirements: fixture.WithStorage(fixture.Small, "10Gi"),
 		StorageClassName:     &fixture.Context.LocalVolumeStorageClass,
+		BaseImage:            baseImage,
 		ComponentSpec: v1alpha1.ComponentSpec{
-			Image: util.BuildImage("tidb-binlog", fixture.Context.TiDBClusterConfig.ImageVersion, fixture.Context.BinlogConfig.Image),
+			Version: version,
 		},
 		Config: &config.GenericConfig{},
 	}

--- a/pkg/test-infra/util/util.go
+++ b/pkg/test-infra/util/util.go
@@ -92,6 +92,7 @@ func ApplyObject(client client.Client, object runtime.Object) error {
 
 // BuildImage builds a image URL: ${fixture.Context.HubAddress}/${fixture.Context.DockerRepository}/$name:$tag
 // or returns the fullImageIfNotEmpty if it's not empty
+// Attention: since tidb-operator v1.3.0, image is deprecated actually, so don't use this function to set the tidbCluster CRD component images
 func BuildImage(name, tag, fullImageIfNotEmpty string) string {
 	if len(fullImageIfNotEmpty) > 0 {
 		return fullImageIfNotEmpty
@@ -108,6 +109,16 @@ func BuildImage(name, tag, fullImageIfNotEmpty string) string {
 	b.WriteString(tag)
 
 	return b.String()
+}
+
+// BuildBaseImageAndVersion generates baseImage and version for tidbCluster CRD components.
+func BuildBaseImageAndVersion(name, tag, fullImageIfNotEmpty string) (baseImage string, version *string) {
+	image := BuildImage(name, tag, fullImageIfNotEmpty)
+	s := strings.Split(image, ":")
+	if len(s) == 1 {
+		return image, nil
+	}
+	return s[0], &s[1]
 }
 
 func chooseHub(image string) string {


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Since tidb-operator v1.3.0 the image field of tidbCluster component is deprecated actually and should replace it with baseImage + version to set the component image after that.

Ref: https://github.com/pingcap/tidb-operator/pull/4151

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
