### PR TITLE
fix: empty version validation failure after deploy tidb-operator webhook component

### DIFF
--- a/pkg/test-infra/clusters.go
+++ b/pkg/test-infra/clusters.go
@@ -177,7 +177,7 @@ func NewBinlogCluster(namespace, name string, conf fixture.TiDBClusterConfig) cl
 		StorageClassName:     &fixture.Context.LocalVolumeStorageClass,
 		BaseImage:            baseImage,
 		ComponentSpec: v1alpha1.ComponentSpec{
-			Version: version,
+			Version: &version,
 		},
 		Config: &config.GenericConfig{},
 	}

--- a/pkg/test-infra/tidb/recommend.go
+++ b/pkg/test-infra/tidb/recommend.go
@@ -56,7 +56,7 @@ func (t *Recommendation) EnableTiFlash(clusterConfig fixture.TiDBClusterConfig) 
 			MaxFailoverCount: pointer.Int32Ptr(int32(0)),
 			BaseImage:        baseImage,
 			ComponentSpec: v1alpha1.ComponentSpec{
-				Version: version,
+				Version: &version,
 			},
 			StorageClaims: []v1alpha1.StorageClaim{
 				{
@@ -155,6 +155,7 @@ func RecommendedTiDBCluster(ns, name string, clusterConfig fixture.TiDBClusterCo
 	tikvBaseImage, tikvVersion := util.BuildBaseImageAndVersion("tikv", clusterConfig.ImageVersion, clusterConfig.TiKVImage)
 	tidbBaseImage, tidbVersion := util.BuildBaseImageAndVersion("tidb", clusterConfig.ImageVersion, clusterConfig.TiDBImage)
 	ticdcBaseImage, ticdcVersion := util.BuildBaseImageAndVersion("ticdc", clusterConfig.ImageVersion, clusterConfig.TiCDCImage)
+	version := tidbVersion
 
 	r := &Recommendation{
 		TidbCluster: &v1alpha1.TidbCluster{
@@ -171,13 +172,14 @@ func RecommendedTiDBCluster(ns, name string, clusterConfig fixture.TiDBClusterCo
 				PVReclaimPolicy: &reclaimDelete,
 				EnablePVReclaim: &enablePVReclaim,
 				ImagePullPolicy: corev1.PullAlways,
+				Version:         version,
 				PD: &v1alpha1.PDSpec{
 					Replicas:             int32(clusterConfig.PDReplicas),
 					ResourceRequirements: fixture.WithStorage(fixture.Medium, "10Gi"),
 					StorageClassName:     &pdDataStorageClass,
 					BaseImage:            pdBaseImage,
 					ComponentSpec: v1alpha1.ComponentSpec{
-						Version: pdVersion,
+						Version: &pdVersion,
 					},
 					StorageVolumes: []v1alpha1.StorageVolume{
 						{
@@ -204,7 +206,7 @@ func RecommendedTiDBCluster(ns, name string, clusterConfig fixture.TiDBClusterCo
 					MaxFailoverCount: pointer.Int32Ptr(int32(0)),
 					BaseImage:        tikvBaseImage,
 					ComponentSpec: v1alpha1.ComponentSpec{
-						Version: tikvVersion,
+						Version: &tikvVersion,
 					},
 				},
 				TiDB: &v1alpha1.TiDBSpec{
@@ -229,7 +231,7 @@ func RecommendedTiDBCluster(ns, name string, clusterConfig fixture.TiDBClusterCo
 					MaxFailoverCount: pointer.Int32Ptr(int32(0)),
 					BaseImage:        tidbBaseImage,
 					ComponentSpec: v1alpha1.ComponentSpec{
-						Version: tidbVersion,
+						Version: &tidbVersion,
 					},
 					StorageVolumes: []v1alpha1.StorageVolume{
 						{
@@ -243,7 +245,7 @@ func RecommendedTiDBCluster(ns, name string, clusterConfig fixture.TiDBClusterCo
 					Replicas:  int32(clusterConfig.TiCDCReplicas),
 					BaseImage: ticdcBaseImage,
 					ComponentSpec: v1alpha1.ComponentSpec{
-						Version: ticdcVersion,
+						Version: &ticdcVersion,
 					},
 					ResourceRequirements: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{

--- a/pkg/test-infra/util/util.go
+++ b/pkg/test-infra/util/util.go
@@ -112,13 +112,13 @@ func BuildImage(name, tag, fullImageIfNotEmpty string) string {
 }
 
 // BuildBaseImageAndVersion generates baseImage and version for tidbCluster CRD components.
-func BuildBaseImageAndVersion(name, tag, fullImageIfNotEmpty string) (baseImage string, version *string) {
+func BuildBaseImageAndVersion(name, tag, fullImageIfNotEmpty string) (baseImage string, version string) {
 	image := BuildImage(name, tag, fullImageIfNotEmpty)
 	s := strings.Split(image, ":")
 	if len(s) == 1 {
-		return image, nil
+		return image, "latest"
 	}
-	return s[0], &s[1]
+	return s[0], s[1]
 }
 
 func chooseHub(image string) string {


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

This PR resolves the issue: `2022/04/11 12:00:18 suit.go:84: [fatal] deploy a cluster failed, maybe has no enough resources, err: admission webhook "[validating.admission.tidb.pingcap.com](http://validating.admission.tidb.pingcap.com/)" denied the request: spec.version: Invalid value: "": version must not be empty`

### What is changed and how does it work?

Set the version field using the version part of tidb image.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
